### PR TITLE
Manage layout persistence via interface

### DIFF
--- a/vuu-ui/packages/vuu-layout/src/index.ts
+++ b/vuu-ui/packages/vuu-layout/src/index.ts
@@ -6,6 +6,7 @@ export * from "./DraggableLayout";
 export * from "./flexbox";
 export { Action } from "./layout-action";
 export * from "./layout-header";
+export * from "./layout-persistence";
 export * from "./layout-provider";
 export * from "./layout-reducer";
 export * from "./layout-view";

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -5,7 +5,7 @@ export interface LayoutPersistenceManager {
   /**
    * Saves a new layout
    *
-   * @param metadata - Metadata about the layout to be saved (excluding ID)
+   * @param metadata - Metadata about the layout to be saved
    * @param layout   - Full JSON representation of the layout to be saved
    *
    * @returns ID assigned to the saved layout
@@ -16,7 +16,7 @@ export interface LayoutPersistenceManager {
    * Overwrites an existing layout with a new one
    *
    * @param id       - Unique identifier of the existing layout to be updated
-   * @param metadata - Metadata describing the new layout to overwrite with (excluding ID)
+   * @param metadata - Metadata describing the new layout to overwrite with
    * @param layout   - Full JSON representation of the new layout to overwrite with
    */
   updateLayout: (id: string, metadata: LayoutMetadata, layout: LayoutJSON) => void;
@@ -31,7 +31,7 @@ export interface LayoutPersistenceManager {
   /**
    * Retrieves an existing layout
    *
-   * @param id - Unique identifier of the existing layout to be deleted
+   * @param id - Unique identifier of the existing layout to be retrieved
    *
    * @returns the layout corresponding to provided metadata
    */

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -44,15 +44,6 @@ export interface LayoutPersistenceManager {
    */
   loadMetadata: () => PersistedLayoutMetadata[];
 
-  /**
-   * Retrieves metadata for all existing layouts created by a given user
-   *
-   * @param user - Name of user
-   *
-   * @returns an array of metadata describing all persisted layouts created by {@link user}
-   */
-  loadMetadataByUser: (user: string) => PersistedLayoutMetadata[];
-
   // TODO: should be switched over to load metadata only; remove this
   loadLayouts: () => Layout[];
 }

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -1,5 +1,5 @@
 import { LayoutJSON } from "@finos/vuu-layout";
-import { Layout, LayoutMetadata } from "@finos/vuu-shell";
+import { LayoutMetadata } from "@finos/vuu-shell";
 
 export interface LayoutPersistenceManager {
   /**

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -1,35 +1,32 @@
-import { LayoutJSON } from "../layout-reducer";
+import { LayoutJSON } from "@finos/vuu-layout";
 import { LayoutMetadata } from "@finos/vuu-shell";
 
 export interface LayoutPersistenceManager {
   /**
    * Saves a new layout
    *
-   * @param metadata - Metadata about the layout to be saved (without ID)
+   * @param metadata - Metadata about the layout to be saved (excluding ID)
    * @param layout   - Full JSON representation of the layout to be saved
    *
    * @returns ID assigned to the saved layout
    */
-  saveLayout: (metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => string;
+  saveLayout: (metadata: Omit<LayoutMetadata, "id">) => string;
 
   /**
    * Overwrites an existing layout with a new one
    *
-   * @param metadata - Metadata (including unique identifier) about the existing layout to be overwritten
+   * @param id       - Unique identifier of the existing layout to be updated
+   * @param metadata - Metadata describing the new layout to overwrite with (excluding ID)
    * @param layout   - Full JSON representation of the new layout to overwrite with
-   *
-   * @returns Version number assigned to the updated layout
    */
-  updateLayout: (metadata: LayoutMetadata, layout: LayoutJSON) => number;
+  updateLayout: (id: string, metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => void;
 
   /**
    * Deletes an existing layout
    *
    * @param id - Unique identifier of the existing layout to be deleted
-   *
-   * @returns true if delete was successful, false if delete was unsuccessful
    */
-  deleteLayout: (id: string) => boolean;
+  deleteLayout: (id: string) => void;
 
   /**
    * Retrieves an existing layout

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -1,5 +1,5 @@
 import { LayoutJSON } from "@finos/vuu-layout";
-import { Layout, LayoutMetadata } from "@finos/vuu-shell";
+import { Layout, LayoutMetadata, PersistedLayoutMetadata } from "@finos/vuu-shell";
 
 export interface LayoutPersistenceManager {
   /**
@@ -42,7 +42,7 @@ export interface LayoutPersistenceManager {
    *
    * @returns an array of all persisted layout metadata
    */
-  loadMetadata: () => LayoutMetadata[];
+  loadMetadata: () => PersistedLayoutMetadata[];
 
   /**
    * Retrieves metadata for all existing layouts created by a given user
@@ -51,7 +51,7 @@ export interface LayoutPersistenceManager {
    *
    * @returns an array of metadata describing all persisted layouts created by {@link user}
    */
-  loadMetadataByUser: (user: string) => LayoutMetadata[];
+  loadMetadataByUser: (user: string) => PersistedLayoutMetadata[];
 
   // TODO: should be switched over to load metadata only; remove this
   loadLayouts: () => Layout[];

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -10,7 +10,7 @@ export interface LayoutPersistenceManager {
    *
    * @returns ID assigned to the saved layout
    */
-  saveLayout: (layouts: Layout[]) => string;
+  saveLayout: (layout: Layout) => string;
 
   /**
    * Overwrites an existing layout with a new one

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -1,0 +1,58 @@
+import { LayoutJSON } from "../layout-reducer";
+import { LayoutMetadata } from "@finos/vuu-shell";
+
+export interface LayoutPersistenceManager {
+  /**
+   * Saves a new layout
+   *
+   * @param metadata - Metadata about the layout to be saved (without ID)
+   * @param layout   - Full JSON representation of the layout to be saved
+   *
+   * @returns ID assigned to the saved layout
+   */
+  saveLayout: (metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => string;
+
+  /**
+   * Overwrites an existing layout with a new one
+   *
+   * @param metadata - Metadata (including unique identifier) about the existing layout to be overwritten
+   * @param layout   - Full JSON representation of the new layout to overwrite with
+   *
+   * @returns Version number assigned to the updated layout
+   */
+  updateLayout: (metadata: LayoutMetadata, layout: LayoutJSON) => number;
+
+  /**
+   * Deletes an existing layout
+   *
+   * @param id - Unique identifier of the existing layout to be deleted
+   *
+   * @returns true if delete was successful, false if delete was unsuccessful
+   */
+  deleteLayout: (id: string) => boolean;
+
+  /**
+   * Retrieves an existing layout
+   *
+   * @param id - Unique identifier of the existing layout to be deleted
+   *
+   * @returns the layout corresponding to provided metadata
+   */
+  loadLayout: (id: string) => LayoutJSON;
+
+  /**
+   * Retrieves metadata for all existing layouts
+   *
+   * @returns an array of all persisted layout metadata
+   */
+  loadMetadata: () => LayoutMetadata[];
+
+  /**
+   * Retrieves metadata for all existing layouts created by a given user
+   *
+   * @param user - Name of user
+   *
+   * @returns an array of metadata describing all persisted layouts created by {@link user}
+   */
+  loadMetadataByUser: (user: string) => LayoutMetadata[];
+}

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -10,7 +10,7 @@ export interface LayoutPersistenceManager {
    *
    * @returns ID assigned to the saved layout
    */
-  saveLayout: (layout: Layout) => string;
+  saveLayout: (metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => string;
 
   /**
    * Overwrites an existing layout with a new one

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -1,5 +1,5 @@
 import { LayoutJSON } from "@finos/vuu-layout";
-import { Layout, LayoutMetadata, PersistedLayoutMetadata } from "@finos/vuu-shell";
+import { Layout, LayoutMetadata } from "@finos/vuu-shell";
 
 export interface LayoutPersistenceManager {
   /**
@@ -10,7 +10,7 @@ export interface LayoutPersistenceManager {
    *
    * @returns ID assigned to the saved layout
    */
-  saveLayout: (metadata: LayoutMetadata, layout: LayoutJSON) => string;
+  saveLayout: (metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => string;
 
   /**
    * Overwrites an existing layout with a new one
@@ -19,7 +19,7 @@ export interface LayoutPersistenceManager {
    * @param metadata - Metadata describing the new layout to overwrite with
    * @param layout   - Full JSON representation of the new layout to overwrite with
    */
-  updateLayout: (id: string, metadata: LayoutMetadata, layout: LayoutJSON) => void;
+  updateLayout: (id: string, metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => void;
 
   /**
    * Deletes an existing layout
@@ -42,7 +42,7 @@ export interface LayoutPersistenceManager {
    *
    * @returns an array of all persisted layout metadata
    */
-  loadMetadata: () => PersistedLayoutMetadata[];
+  loadMetadata: () => LayoutMetadata[];
 
   // TODO: should be switched over to load metadata only; remove this
   loadLayouts: () => Layout[];

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -43,7 +43,4 @@ export interface LayoutPersistenceManager {
    * @returns an array of all persisted layout metadata
    */
   loadMetadata: () => LayoutMetadata[];
-
-  // TODO: should be switched over to load metadata only; remove this
-  loadLayouts: () => Layout[];
 }

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -10,7 +10,7 @@ export interface LayoutPersistenceManager {
    *
    * @returns ID assigned to the saved layout
    */
-  saveLayout: (metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => string;
+  saveLayout: (metadata: LayoutMetadata, layout: LayoutJSON) => string;
 
   /**
    * Overwrites an existing layout with a new one
@@ -19,7 +19,7 @@ export interface LayoutPersistenceManager {
    * @param metadata - Metadata describing the new layout to overwrite with (excluding ID)
    * @param layout   - Full JSON representation of the new layout to overwrite with
    */
-  updateLayout: (id: string, metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => void;
+  updateLayout: (id: string, metadata: LayoutMetadata, layout: LayoutJSON) => void;
 
   /**
    * Deletes an existing layout

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -10,7 +10,7 @@ export interface LayoutPersistenceManager {
    *
    * @returns ID assigned to the saved layout
    */
-  saveLayout: (metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => string;
+  createLayout: (metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => string;
 
   /**
    * Overwrites an existing layout with a new one

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -1,5 +1,5 @@
 import { LayoutJSON } from "@finos/vuu-layout";
-import { LayoutMetadata } from "@finos/vuu-shell";
+import { Layout, LayoutMetadata } from "@finos/vuu-shell";
 
 export interface LayoutPersistenceManager {
   /**
@@ -10,7 +10,7 @@ export interface LayoutPersistenceManager {
    *
    * @returns ID assigned to the saved layout
    */
-  saveLayout: (metadata: Omit<LayoutMetadata, "id">) => string;
+  saveLayout: (layouts: Layout[]) => string;
 
   /**
    * Overwrites an existing layout with a new one
@@ -52,4 +52,7 @@ export interface LayoutPersistenceManager {
    * @returns an array of metadata describing all persisted layouts created by {@link user}
    */
   loadMetadataByUser: (user: string) => LayoutMetadata[];
+
+  // TODO: should be switched over to load metadata only; remove this
+  loadLayouts: () => Layout[];
 }

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -5,11 +5,25 @@ import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
 import { getUniqueId } from "@finos/vuu-utils";
 
 export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
-  saveLayout(layouts: Layout[]): string {
-    console.log(`Saving layout as ${layouts[0]?.metadata.name} to group ${layouts[0]?.metadata.group}...`);
+  saveLayout(inputLayouts: Layout[]): string {
+    const layouts = Array.from(inputLayouts);
+
+    if (layouts.length === 0) {
+      return "";
+    }
+    
+    const layout = this.deepCopy(layouts[layouts.length - 1]);
+    console.log(`Saving layout as ${layout.metadata.name} to group ${layout.metadata.group}...`);
+    const id = getUniqueId();
+    layout.metadata.id = id;
+    layouts[layouts.length - 1] = layout;
     saveLocalEntity<Layout[]>("layouts", layouts);
-    return layouts[0]?.metadata.id;
+    return id;
   }
+
+  private deepCopy<T>(object: T): T {
+    return JSON.parse(JSON.stringify(object));
+  };
 
   updateLayout(id: string, newMetadata: Omit<LayoutMetadata, "id">, newLayoutJson: LayoutJSON): void {
     const layouts = this.getExistingLayouts();

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -65,13 +65,6 @@ export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
     return this.getPersistedMetadata(layouts);
   };
 
-  loadMetadataByUser(user: string): PersistedLayoutMetadata[] {
-    const layouts = this.getExistingLayouts()
-      .filter(layout => layout.metadata.user === user);
-
-    return this.getPersistedMetadata(layouts);
-  };
-
   // TODO: remove
   loadLayouts(): Layout[] {
     return this.getExistingLayouts();

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -5,15 +5,23 @@ import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
 import { getUniqueId } from "@finos/vuu-utils";
 
 export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
-  saveLayout(inputLayout: Layout): string {
-    console.log(`Saving layout as ${inputLayout.metadata.name} to group ${inputLayout.metadata.group}...`);
+  saveLayout(inputMetadata: Omit<LayoutMetadata, "id">, inputLayout: LayoutJSON): string {
+    console.log(`Saving layout as ${inputMetadata.name} to group ${inputMetadata.group}...`);
 
-    const layout = this.deepCopy(inputLayout);
     const id = getUniqueId();
-    layout.metadata.id = id;
+
+    const newMetadata = {
+      ...inputMetadata,
+      id: id
+    } as LayoutMetadata;
+
+    const newLayout = {
+      metadata: newMetadata,
+      json: inputLayout
+    } as Layout;
 
     const layouts = this.getExistingLayouts();
-    layouts.push(layout);
+    layouts.push(newLayout);
     saveLocalEntity<Layout[]>("layouts", layouts);
 
     return id;

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -57,8 +57,7 @@ export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
     return getLocalEntity<LayoutMetadata[]>(metadataSaveLocation) || [];
   }
 
-  // TODO: make private
-  loadLayouts(): Layout[] {
+  private loadLayouts(): Layout[] {
     return getLocalEntity<Layout[]>(layoutsSaveLocation) || [];
   }
 

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -5,19 +5,19 @@ import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
 import { getUniqueId } from "@finos/vuu-utils";
 
 export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
-  saveLayout(inputMetadata: Omit<LayoutMetadata, "id">, inputLayout: LayoutJSON): string {
-    console.log(`Saving layout as ${inputMetadata.name} to group ${inputMetadata.group}...`);
+  saveLayout(metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON): string {
+    console.log(`Saving layout as ${metadata.name} to group ${metadata.group}...`);
 
     const id = getUniqueId();
 
     const newMetadata = {
-      ...inputMetadata,
+      ...metadata,
       id: id
     } as LayoutMetadata;
 
     const newLayout = {
       metadata: newMetadata,
-      json: inputLayout
+      json: layout
     } as Layout;
 
     const layouts = this.getExistingLayouts();
@@ -26,10 +26,6 @@ export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
 
     return id;
   }
-
-  private deepCopy<T>(object: T): T {
-    return JSON.parse(JSON.stringify(object));
-  };
 
   updateLayout(id: string, newMetadata: Omit<LayoutMetadata, "id">, newLayoutJson: LayoutJSON): void {
     const layouts = this.getExistingLayouts();

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -8,7 +8,7 @@ const metadataSaveLocation = "layouts/metadata";
 const layoutsSaveLocation = "layouts/layouts";
 
 export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
-  saveLayout(metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON): string {
+  createLayout(metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON): string {
     console.log(`Saving layout as ${metadata.name} to group ${metadata.group}...`);
 
     const existingLayouts = this.loadLayouts();

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -1,0 +1,75 @@
+import { Layout, LayoutMetadata } from "@finos/vuu-shell";
+import { LayoutJSON, LayoutPersistenceManager } from "@finos/vuu-layout";
+
+import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
+import { getUniqueId } from "@finos/vuu-utils";
+
+export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
+  saveLayout(metadata: Omit<LayoutMetadata, "id">): string {
+    console.log(`Saving layout as ${metadata.name} to group ${metadata.group}...`);
+    
+    const existingLayouts = this.getExistingLayouts();
+    const layoutJson = getLocalEntity<LayoutJSON>("api/vui");
+    const generatedId = getUniqueId();
+    
+    if (layoutJson) {
+      const newMetadata = {...metadata, id: generatedId} as LayoutMetadata;
+      const newLayout = {json: layoutJson, metadata: newMetadata} as Layout;
+      existingLayouts.push(newLayout);
+    }
+
+    saveLocalEntity<Layout[]>("layouts", existingLayouts);
+
+    return generatedId;
+  }
+
+  updateLayout(id: string, newMetadata: Omit<LayoutMetadata, "id">, newLayoutJson: LayoutJSON): void {
+    const layouts = this.getExistingLayouts();
+    const layoutJson = getLocalEntity<LayoutJSON>("api/vui");
+    
+    if (layoutJson) {
+      layouts.filter(layout => layout.metadata.id !== id)
+      const newLayout = {json: newLayoutJson, metadata: newMetadata} as Layout;
+      layouts.push(newLayout);
+    }
+
+    saveLocalEntity<Layout[]>("layouts", layouts);
+  };
+
+  deleteLayout(id: string): void {
+    const layouts = this.getExistingLayouts().filter(layout => layout.metadata.id !== id);
+    saveLocalEntity<Layout[]>("layouts", layouts);
+  };
+
+  loadLayout(id: string): LayoutJSON {
+    const layout = this.getExistingLayouts().filter(layout => layout.metadata.id === id);
+    
+    switch (layout.length) {
+      case 1: {
+        return layout[0].json;
+      }
+      case 0: {
+        console.log(`WARNING: no layout exists for ID "${id}"; returning empty layout`);
+        return {} as LayoutJSON;
+      }
+      default: {
+        console.log(`WARNING: multiple layouts exist for ID "${id}"; returning first instance`)
+        return layout[0].json;
+      }
+    }
+  };
+
+  loadMetadata(): LayoutMetadata[] {
+    return this.getExistingLayouts().map(layout => layout.metadata);
+  };
+
+  loadMetadataByUser(user: string): LayoutMetadata[] {
+    return this.getExistingLayouts()
+      .filter(layout => layout.metadata.user === user)
+      .map(layout => layout.metadata);
+  };
+
+  private getExistingLayouts() {
+    return getLocalEntity<Layout[]>("layouts") || [];
+  }
+}

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -24,14 +24,15 @@ export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
   }
 
   updateLayout(id: string, newMetadata: LayoutMetadata, newLayoutJson: LayoutJSON): void {
-    const layouts = this.getExistingLayouts();
-    const layoutJson = getLocalEntity<LayoutJSON>("api/vui");
+    const layouts = this.getExistingLayouts().filter(layout => layout.id !== id);
 
-    if (layoutJson) {
-      layouts.filter(layout => layout.id !== id)
-      const newLayout = {json: newLayoutJson, metadata: newMetadata} as Layout;
-      layouts.push(newLayout);
-    }
+    const newLayout = {
+      id: id,
+      json: newLayoutJson,
+      metadata: newMetadata
+    };
+
+    layouts.push(newLayout);
 
     saveLocalEntity<Layout[]>("layouts", layouts);
   };
@@ -67,7 +68,7 @@ export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
   loadMetadataByUser(user: string): PersistedLayoutMetadata[] {
     const layouts = this.getExistingLayouts()
       .filter(layout => layout.metadata.user === user);
-    
+
     return this.getPersistedMetadata(layouts);
   };
 

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -1,4 +1,4 @@
-import { Layout, LayoutMetadata } from "@finos/vuu-shell";
+import { Layout, LayoutMetadata, PersistedLayoutMetadata } from "@finos/vuu-shell";
 import { LayoutJSON, LayoutPersistenceManager } from "@finos/vuu-layout";
 
 import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
@@ -59,22 +59,38 @@ export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
     }
   };
 
-  loadMetadata(): LayoutMetadata[] {
-    return this.getExistingLayouts().map(layout => layout.metadata);
+  loadMetadata(): PersistedLayoutMetadata[] {
+    const layouts = this.getExistingLayouts();
+    return this.getPersistedMetadata(layouts);
   };
 
-  loadMetadataByUser(user: string): LayoutMetadata[] {
-    return this.getExistingLayouts()
-      .filter(layout => layout.metadata.user === user)
-      .map(layout => layout.metadata);
+  loadMetadataByUser(user: string): PersistedLayoutMetadata[] {
+    const layouts = this.getExistingLayouts()
+      .filter(layout => layout.metadata.user === user);
+    
+    return this.getPersistedMetadata(layouts);
   };
+
+  // TODO: remove
+  loadLayouts(): Layout[] {
+    return this.getExistingLayouts();
+  }
 
   private getExistingLayouts() {
     return getLocalEntity<Layout[]>("layouts") || [];
   }
 
-  // TODO: remove
-  loadLayouts(): Layout[] {
-    return this.getExistingLayouts();
+  private getPersistedMetadata(layouts: Layout[]): PersistedLayoutMetadata[] {
+    const metadata = [] as PersistedLayoutMetadata[];
+
+    for (var layout of layouts) {
+      const newMetadata = {
+        id: layout.id,
+        metadata: layout.metadata
+      } as PersistedLayoutMetadata;
+      metadata.push(newMetadata);
+    }
+
+    return metadata;
   }
 }

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -5,28 +5,16 @@ import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
 import { getUniqueId } from "@finos/vuu-utils";
 
 export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
-  saveLayout(metadata: Omit<LayoutMetadata, "id">): string {
-    console.log(`Saving layout as ${metadata.name} to group ${metadata.group}...`);
-    
-    const existingLayouts = this.getExistingLayouts();
-    const layoutJson = getLocalEntity<LayoutJSON>("api/vui");
-    const generatedId = getUniqueId();
-    
-    if (layoutJson) {
-      const newMetadata = {...metadata, id: generatedId} as LayoutMetadata;
-      const newLayout = {json: layoutJson, metadata: newMetadata} as Layout;
-      existingLayouts.push(newLayout);
-    }
-
-    saveLocalEntity<Layout[]>("layouts", existingLayouts);
-
-    return generatedId;
+  saveLayout(layouts: Layout[]): string {
+    console.log(`Saving layout as ${layouts[0]?.metadata.name} to group ${layouts[0]?.metadata.group}...`);
+    saveLocalEntity<Layout[]>("layouts", layouts);
+    return layouts[0]?.metadata.id;
   }
 
   updateLayout(id: string, newMetadata: Omit<LayoutMetadata, "id">, newLayoutJson: LayoutJSON): void {
     const layouts = this.getExistingLayouts();
     const layoutJson = getLocalEntity<LayoutJSON>("api/vui");
-    
+
     if (layoutJson) {
       layouts.filter(layout => layout.metadata.id !== id)
       const newLayout = {json: newLayoutJson, metadata: newMetadata} as Layout;
@@ -43,7 +31,7 @@ export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
 
   loadLayout(id: string): LayoutJSON {
     const layout = this.getExistingLayouts().filter(layout => layout.metadata.id === id);
-    
+
     switch (layout.length) {
       case 1: {
         return layout[0].json;
@@ -71,5 +59,10 @@ export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
 
   private getExistingLayouts() {
     return getLocalEntity<Layout[]>("layouts") || [];
+  }
+
+  // TODO: remove
+  loadLayouts(): Layout[] {
+    return this.getExistingLayouts();
   }
 }

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -5,19 +5,17 @@ import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
 import { getUniqueId } from "@finos/vuu-utils";
 
 export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
-  saveLayout(inputLayouts: Layout[]): string {
-    const layouts = Array.from(inputLayouts);
+  saveLayout(inputLayout: Layout): string {
+    console.log(`Saving layout as ${inputLayout.metadata.name} to group ${inputLayout.metadata.group}...`);
 
-    if (layouts.length === 0) {
-      return "";
-    }
-    
-    const layout = this.deepCopy(layouts[layouts.length - 1]);
-    console.log(`Saving layout as ${layout.metadata.name} to group ${layout.metadata.group}...`);
+    const layout = this.deepCopy(inputLayout);
     const id = getUniqueId();
     layout.metadata.id = id;
-    layouts[layouts.length - 1] = layout;
+
+    const layouts = this.getExistingLayouts();
+    layouts.push(layout);
     saveLocalEntity<Layout[]>("layouts", layouts);
+
     return id;
   }
 

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -5,18 +5,14 @@ import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
 import { getUniqueId } from "@finos/vuu-utils";
 
 export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
-  saveLayout(metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON): string {
+  saveLayout(metadata: LayoutMetadata, layout: LayoutJSON): string {
     console.log(`Saving layout as ${metadata.name} to group ${metadata.group}...`);
 
     const id = getUniqueId();
 
-    const newMetadata = {
-      ...metadata,
-      id: id
-    } as LayoutMetadata;
-
     const newLayout = {
-      metadata: newMetadata,
+      id: id,
+      metadata: metadata,
       json: layout
     } as Layout;
 
@@ -27,12 +23,12 @@ export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
     return id;
   }
 
-  updateLayout(id: string, newMetadata: Omit<LayoutMetadata, "id">, newLayoutJson: LayoutJSON): void {
+  updateLayout(id: string, newMetadata: LayoutMetadata, newLayoutJson: LayoutJSON): void {
     const layouts = this.getExistingLayouts();
     const layoutJson = getLocalEntity<LayoutJSON>("api/vui");
 
     if (layoutJson) {
-      layouts.filter(layout => layout.metadata.id !== id)
+      layouts.filter(layout => layout.id !== id)
       const newLayout = {json: newLayoutJson, metadata: newMetadata} as Layout;
       layouts.push(newLayout);
     }
@@ -41,12 +37,12 @@ export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
   };
 
   deleteLayout(id: string): void {
-    const layouts = this.getExistingLayouts().filter(layout => layout.metadata.id !== id);
+    const layouts = this.getExistingLayouts().filter(layout => layout.id !== id);
     saveLocalEntity<Layout[]>("layouts", layouts);
   };
 
   loadLayout(id: string): LayoutJSON {
-    const layout = this.getExistingLayouts().filter(layout => layout.metadata.id === id);
+    const layout = this.getExistingLayouts().filter(layout => layout.id === id);
 
     switch (layout.length) {
       case 1: {

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/index.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/index.ts
@@ -1,1 +1,2 @@
 export * from './LayoutPersistenceManager';
+export * from './LocalLayoutPersistenceManager';

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/index.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/index.ts
@@ -1,0 +1,1 @@
+export * from './LayoutPersistenceManager';

--- a/vuu-ui/packages/vuu-shell/src/layout-management/LayoutList.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/LayoutList.tsx
@@ -12,14 +12,12 @@ type LayoutGroups = {
 const classBase = "vuuLayoutList";
 
 export const LayoutsList = (props: HTMLAttributes<HTMLDivElement>) => {
-    const { layouts } = useLayoutManager();
-
-    const layoutMetadata = layouts.map(layout => layout.metadata)
+    const { layoutMetadata } = useLayoutManager();
 
     const handleLoadLayout = (layoutId?: string) => {
         // TODO load layout
         console.log("loading layout with id", layoutId)
-        console.log("json:", layouts.find(layout => layout.metadata.id === layoutId))
+        console.log("json:", layoutMetadata.find(metadata => metadata.id === layoutId))
     }
 
     const layoutsByGroup = layoutMetadata.reduce((acc: LayoutGroups, cur) => {

--- a/vuu-ui/packages/vuu-shell/src/layout-management/SaveLayoutPanel.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/SaveLayoutPanel.tsx
@@ -33,7 +33,7 @@ type RadioValue = typeof radioValues[number];
 
 type SaveLayoutPanelProps = {
   onCancel: () => void;
-  onSave: (layoutMetadata: LayoutMetadata) => void;
+  onSave: (layoutMetadata: Omit<LayoutMetadata, "id">) => void;
   componentId?: string
 };
 

--- a/vuu-ui/packages/vuu-shell/src/layout-management/SaveLayoutPanel.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/SaveLayoutPanel.tsx
@@ -33,7 +33,7 @@ type RadioValue = typeof radioValues[number];
 
 type SaveLayoutPanelProps = {
   onCancel: () => void;
-  onSave: (layoutMetadata: Omit<LayoutMetadata, "id">) => void;
+  onSave: (layoutMetadata: LayoutMetadata) => void;
   componentId?: string
 };
 

--- a/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
@@ -8,6 +8,11 @@ export type LayoutMetadata = {
   date: string;
 };
 
+export type PersistedLayoutMetadata = {
+  id: string,
+  metadata: LayoutMetadata
+}
+
 export type Layout = {
   id: string,
   json: LayoutJSON;

--- a/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
@@ -12,5 +12,4 @@ export type LayoutMetadata = {
 export type Layout = {
   id: string,
   json: LayoutJSON;
-  metadata: LayoutMetadata;
 };

--- a/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
@@ -6,10 +6,10 @@ export type LayoutMetadata = {
   screenshot: string;
   user: string;
   date: string;
-  id: string;
 };
 
 export type Layout = {
+  id: string,
   json: LayoutJSON;
   metadata: LayoutMetadata;
 };

--- a/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
@@ -1,17 +1,13 @@
 import { LayoutJSON } from "@finos/vuu-layout";
 
 export type LayoutMetadata = {
+  id: string;
   name: string;
   group: string;
   screenshot: string;
   user: string;
   date: string;
 };
-
-export type PersistedLayoutMetadata = {
-  id: string,
-  metadata: LayoutMetadata
-}
 
 export type Layout = {
   id: string,

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -28,12 +28,12 @@ export const LayoutManagementProvider = (props: {
       const generatedId = persistenceManager.saveLayout(metadata, json);
 
       // Update state
-      const newMetadata = {
+      const newMetadata: LayoutMetadata = {
         ...metadata,
         id: generatedId
       };
 
-      const newLayout = {
+      const newLayout: Layout = {
         json: json,
         id: generatedId
       };

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -13,7 +13,8 @@ export const LayoutManagementProvider = (props: {
     children: JSX.Element | JSX.Element[]
   }) => {
   const [layouts, setLayouts] = useState<Layout[]>([]);
-  const [tempLayout, setTempLayout] = useState<Layout>();
+  const [tempLayout, setTempLayout] = useState<LayoutJSON>();
+  const [tempMetadata, setTempMetadata] = useState<Omit<LayoutMetadata, "id">>();
 
   useEffect(() => {
     const loadedLayouts = props.persistenceManager.loadLayouts();
@@ -21,21 +22,28 @@ export const LayoutManagementProvider = (props: {
   }, [])
 
   useEffect(() => {
-    if (tempLayout) {
+    if (tempLayout && tempMetadata) {
       // Persist layouts
-      const generatedId = props.persistenceManager.saveLayout(tempLayout);
+      const generatedId = props.persistenceManager.saveLayout(tempMetadata, tempLayout);
 
       // Update state
-      const newLayout = tempLayout;
-      newLayout.metadata.id = generatedId;
+      const newLayout = {
+        json: tempLayout,
+        metadata: {
+          ...tempMetadata,
+          id: generatedId
+        }
+      } as Layout;
+
       setLayouts(prev => [...prev, newLayout]);
     }
-  }, [tempLayout])
+  }, [tempLayout, tempMetadata])
 
   const saveLayout = useCallback((metadata: Omit<LayoutMetadata, "id">) => {
     const json = getLocalEntity<LayoutJSON>("api/vui");
     if (json) {
-      setTempLayout({ metadata: { ...metadata, id: "" }, json })
+      setTempLayout(json);
+      setTempMetadata(metadata);
     }
   }, [])
 

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -5,7 +5,7 @@ import { LayoutMetadata, Layout } from "./layoutTypes";
 
 export const LayoutManagementContext = React.createContext<{
   layouts: Layout[],
-  saveLayout: (n: Omit<LayoutMetadata, "id">) => void
+  saveLayout: (n: LayoutMetadata) => void
 }>({ layouts: [], saveLayout: () => { } })
 
 export const LayoutManagementProvider = (props: {
@@ -13,8 +13,8 @@ export const LayoutManagementProvider = (props: {
     children: JSX.Element | JSX.Element[]
   }) => {
   const [layouts, setLayouts] = useState<Layout[]>([]);
-  const [tempLayout, setTempLayout] = useState<LayoutJSON>();
-  const [tempMetadata, setTempMetadata] = useState<Omit<LayoutMetadata, "id">>();
+  const [layout, setLayout] = useState<LayoutJSON>();
+  const [metadata, setMetadata] = useState<LayoutMetadata>();
 
   useEffect(() => {
     const loadedLayouts = props.persistenceManager.loadLayouts();
@@ -22,28 +22,26 @@ export const LayoutManagementProvider = (props: {
   }, [])
 
   useEffect(() => {
-    if (tempLayout && tempMetadata) {
+    if (layout && metadata) {
       // Persist layouts
-      const generatedId = props.persistenceManager.saveLayout(tempMetadata, tempLayout);
+      const generatedId = props.persistenceManager.saveLayout(metadata, layout);
 
       // Update state
       const newLayout = {
-        json: tempLayout,
-        metadata: {
-          ...tempMetadata,
-          id: generatedId
-        }
+        json: layout,
+        metadata: metadata,
+        id: generatedId
       } as Layout;
 
       setLayouts(prev => [...prev, newLayout]);
     }
-  }, [tempLayout, tempMetadata])
+  }, [layout, metadata])
 
-  const saveLayout = useCallback((metadata: Omit<LayoutMetadata, "id">) => {
+  const saveLayout = useCallback((metadata: LayoutMetadata) => {
     const json = getLocalEntity<LayoutJSON>("api/vui");
     if (json) {
-      setTempLayout(json);
-      setTempMetadata(metadata);
+      setLayout(json);
+      setMetadata(metadata);
     }
   }, [])
 

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useContext, useEffect } from "react";
-import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
-import { LayoutJSON, LocalLayoutPersistenceManager } from "@finos/vuu-layout";
+import { getLocalEntity } from "@finos/vuu-filters";
+import { LayoutJSON, LayoutPersistenceManager } from "@finos/vuu-layout";
 import { getUniqueId } from "@finos/vuu-utils";
 import { LayoutMetadata, Layout } from "./layoutTypes";
 
@@ -9,19 +9,19 @@ export const LayoutManagementContext = React.createContext<{
   saveLayout: (n: Omit<LayoutMetadata, "id">) => void
 }>({ layouts: [], saveLayout: () => { } })
 
-export const LayoutManagementProvider = (props: { children: JSX.Element | JSX.Element[] }) => {
-
-  const persistenceManager = new LocalLayoutPersistenceManager();
-
+export const LayoutManagementProvider = (props: {
+    persistenceManager: LayoutPersistenceManager,
+    children: JSX.Element | JSX.Element[]
+  }) => {
   const [layouts, setLayouts] = useState<Layout[]>([]);
 
   useEffect(() => {
-    const layouts = persistenceManager.loadLayouts();
+    const layouts = props.persistenceManager.loadLayouts();
     setLayouts(layouts || [])
   }, [])
 
   useEffect(() => {
-    persistenceManager.saveLayout(layouts);
+    props.persistenceManager.saveLayout(layouts);
   }, [layouts])
 
   const saveLayout = useCallback((metadata: Omit<LayoutMetadata, "id">) => {

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useCallback, useContext, useEffect } from "react";
 import { getLocalEntity } from "@finos/vuu-filters";
-import { LayoutJSON, LayoutPersistenceManager } from "@finos/vuu-layout";
+import { LayoutJSON, LocalLayoutPersistenceManager } from "@finos/vuu-layout";
 import { LayoutMetadata, Layout } from "./layoutTypes";
+
+const persistenceManager = new LocalLayoutPersistenceManager();
 
 export const LayoutManagementContext = React.createContext<{
   layouts: Layout[],
@@ -10,14 +12,13 @@ export const LayoutManagementContext = React.createContext<{
 }>({ layouts: [], layoutMetadata: [], saveLayout: () => { } })
 
 export const LayoutManagementProvider = (props: {
-    persistenceManager: LayoutPersistenceManager,
     children: JSX.Element | JSX.Element[]
   }) => {
   const [layouts, setLayouts] = useState<Layout[]>([]);
   const [layoutMetadata, setLayoutMetadata] = useState<LayoutMetadata[]>([]);
 
   useEffect(() => {
-    const loadedLayouts = props.persistenceManager.loadLayouts();
+    const loadedLayouts = persistenceManager.loadLayouts();
     setLayouts(loadedLayouts || [])
   }, [])
 
@@ -26,7 +27,7 @@ export const LayoutManagementProvider = (props: {
 
     if (json) {
       // Persist layouts
-      const generatedId = props.persistenceManager.saveLayout(metadata, json);
+      const generatedId = persistenceManager.saveLayout(metadata, json);
 
       // Update state
       const newMetadata = {

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -33,12 +33,12 @@ export const LayoutManagementProvider = (props: {
       const newMetadata = {
         ...metadata,
         id: generatedId
-      } as LayoutMetadata;
+      };
 
       const newLayout = {
         json: json,
         id: generatedId
-      } as Layout;
+      };
 
       setLayouts(prev => [...prev, newLayout]);
       setLayoutMetadata(prev => [...prev, newMetadata]);

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useContext, useEffect } from "react";
 import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
-import { LayoutJSON } from "@finos/vuu-layout";
+import { LayoutJSON, LocalLayoutPersistenceManager } from "@finos/vuu-layout";
 import { getUniqueId } from "@finos/vuu-utils";
 import { LayoutMetadata, Layout } from "./layoutTypes";
 
@@ -11,19 +11,21 @@ export const LayoutManagementContext = React.createContext<{
 
 export const LayoutManagementProvider = (props: { children: JSX.Element | JSX.Element[] }) => {
 
-  const [layouts, setLayouts] = useState<Layout[]>([])
+  const persistenceManager = new LocalLayoutPersistenceManager();
+
+  const [layouts, setLayouts] = useState<Layout[]>([]);
 
   useEffect(() => {
-    const layouts = getLocalEntity<Layout[]>("layouts")
+    const layouts = persistenceManager.loadLayouts();
     setLayouts(layouts || [])
   }, [])
 
   useEffect(() => {
-    saveLocalEntity<Layout[]>("layouts", layouts)
+    persistenceManager.saveLayout(layouts);
   }, [layouts])
 
   const saveLayout = useCallback((metadata: Omit<LayoutMetadata, "id">) => {
-    const json = getLocalEntity<LayoutJSON>("api/vui")
+    const json = getLocalEntity<LayoutJSON>("api/vui");
     if (json) {
       setLayouts(prev =>
         [

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -6,20 +6,18 @@ import { LayoutMetadata, Layout } from "./layoutTypes";
 const persistenceManager = new LocalLayoutPersistenceManager();
 
 export const LayoutManagementContext = React.createContext<{
-  layouts: Layout[],
   layoutMetadata: LayoutMetadata[],
   saveLayout: (n: Omit<LayoutMetadata, "id">) => void
-}>({ layouts: [], layoutMetadata: [], saveLayout: () => { } })
+}>({ layoutMetadata: [], saveLayout: () => { } })
 
 export const LayoutManagementProvider = (props: {
     children: JSX.Element | JSX.Element[]
   }) => {
-  const [layouts, setLayouts] = useState<Layout[]>([]);
   const [layoutMetadata, setLayoutMetadata] = useState<LayoutMetadata[]>([]);
 
   useEffect(() => {
-    const loadedLayouts = persistenceManager.loadLayouts();
-    setLayouts(loadedLayouts || [])
+    const loadedMetadata = persistenceManager.loadMetadata();
+    setLayoutMetadata(loadedMetadata || [])
   }, [])
 
   const saveLayout = useCallback((metadata: Omit<LayoutMetadata, "id">) => {
@@ -40,13 +38,12 @@ export const LayoutManagementProvider = (props: {
         id: generatedId
       };
 
-      setLayouts(prev => [...prev, newLayout]);
       setLayoutMetadata(prev => [...prev, newMetadata]);
     }
   }, [])
 
   return (
-    <LayoutManagementContext.Provider value={{ layouts, layoutMetadata, saveLayout }} >
+    <LayoutManagementContext.Provider value={{ layoutMetadata, saveLayout }} >
       {props.children}
     </LayoutManagementContext.Provider>
   )

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -36,7 +36,6 @@ export const LayoutManagementProvider = (props: {
 
       const newLayout = {
         json: json,
-        metadata: newMetadata,
         id: generatedId
       } as Layout;
 

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -25,7 +25,7 @@ export const LayoutManagementProvider = (props: {
 
     if (json) {
       // Persist layouts
-      const generatedId = persistenceManager.saveLayout(metadata, json);
+      const generatedId = persistenceManager.createLayout(metadata, json);
 
       // Update state
       const newMetadata: LayoutMetadata = {

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useContext, useEffect } from "react";
 import { getLocalEntity } from "@finos/vuu-filters";
 import { LayoutJSON, LocalLayoutPersistenceManager } from "@finos/vuu-layout";
-import { LayoutMetadata, Layout } from "./layoutTypes";
+import { LayoutMetadata } from "./layoutTypes";
 
 const persistenceManager = new LocalLayoutPersistenceManager();
 
@@ -33,14 +33,11 @@ export const LayoutManagementProvider = (props: {
         id: generatedId
       };
 
-      const newLayout: Layout = {
-        json: json,
-        id: generatedId
-      };
-
       setLayoutMetadata(prev => [...prev, newMetadata]);
     }
   }, [])
+
+  // TODO: add loadLayout function
 
   return (
     <LayoutManagementContext.Provider value={{ layoutMetadata, saveLayout }} >

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -13,7 +13,7 @@ export const LayoutManagementProvider = (props: {
     children: JSX.Element | JSX.Element[]
   }) => {
   const [layouts, setLayouts] = useState<Layout[]>([]);
-  const [tempLayouts, setTempLayouts] = useState<Layout[]>([]);
+  const [tempLayout, setTempLayout] = useState<Layout>();
 
   useEffect(() => {
     const loadedLayouts = props.persistenceManager.loadLayouts();
@@ -21,21 +21,21 @@ export const LayoutManagementProvider = (props: {
   }, [])
 
   useEffect(() => {
-    if (tempLayouts.length !== 0) {
+    if (tempLayout) {
       // Persist layouts
-      const generatedId = props.persistenceManager.saveLayout([...layouts, ...tempLayouts]);
+      const generatedId = props.persistenceManager.saveLayout(tempLayout);
 
       // Update state
-      const newLayout = tempLayouts[0];
+      const newLayout = tempLayout;
       newLayout.metadata.id = generatedId;
       setLayouts(prev => [...prev, newLayout]);
     }
-  }, [tempLayouts])
+  }, [tempLayout])
 
   const saveLayout = useCallback((metadata: Omit<LayoutMetadata, "id">) => {
     const json = getLocalEntity<LayoutJSON>("api/vui");
     if (json) {
-      setTempLayouts([...layouts, { metadata: { ...metadata, id: "" }, json }])
+      setTempLayout({ metadata: { ...metadata, id: "" }, json })
     }
   }, [])
 

--- a/vuu-ui/packages/vuu-shell/src/left-nav/LeftNav.tsx
+++ b/vuu-ui/packages/vuu-shell/src/left-nav/LeftNav.tsx
@@ -146,7 +146,7 @@ export const LeftNav = ({
           Layout Templates
         </div>
         <div className="vuuLeftNav-drawer">
-          <LayoutsList layouts={[]} />
+          <LayoutsList/>
         </div>
       </Stack>
     </div>

--- a/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
@@ -187,9 +187,8 @@ const ShellWithNewTheme = () => {
 };
 
 export const ShellWithNewThemeAndLayoutManagement = () => {
-  const pm = new LocalLayoutPersistenceManager();
   return (
-    <LayoutManagementProvider persistenceManager={pm}>
+    <LayoutManagementProvider>
       <ShellWithNewTheme />
     </LayoutManagementProvider>
   )

--- a/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
@@ -26,7 +26,6 @@ import {
   MenuBuilder,
 } from "@finos/vuu-data-types";
 import { AutoTableNext } from "../Table/TableNext.examples";
-import { LocalLayoutPersistenceManager } from "@finos/vuu-layout";
 
 import "./NewTheme.examples.css";
 
@@ -44,11 +43,12 @@ const ShellWithNewTheme = () => {
     setDialogContent(undefined);
   }, []);
 
-  const persistenceManager = new LocalLayoutPersistenceManager();
+  const { saveLayout } = useLayoutManager();
 
   const handleSave = useCallback((layoutMetadata: Omit<LayoutMetadata, "id">) => {
-    persistenceManager.saveLayout(layoutMetadata);
-    setDialogContent(undefined);
+    console.log(`Save layout as ${layoutMetadata.name} to group ${layoutMetadata.group}`);
+    saveLayout(layoutMetadata)
+    setDialogContent(undefined)
   }, []);
 
   const [buildMenuOptions, handleMenuAction] = useMemo<
@@ -176,7 +176,6 @@ const ShellWithNewTheme = () => {
           style={{ maxHeight: 500, borderColor: "#6d188b" }}
           title={"Save Layout"}
           hideCloseButton
-          headerProps={{ className: "dialogHeader" }}
         >
           {dialogContent}
         </Dialog>

--- a/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
@@ -26,6 +26,7 @@ import {
   MenuBuilder,
 } from "@finos/vuu-data-types";
 import { AutoTableNext } from "../Table/TableNext.examples";
+import { LocalLayoutPersistenceManager } from "@finos/vuu-layout";
 
 import "./NewTheme.examples.css";
 
@@ -43,12 +44,11 @@ const ShellWithNewTheme = () => {
     setDialogContent(undefined);
   }, []);
 
-  const { saveLayout } = useLayoutManager();
+  const persistenceManager = new LocalLayoutPersistenceManager();
 
   const handleSave = useCallback((layoutMetadata: Omit<LayoutMetadata, "id">) => {
-    console.log(`Save layout as ${layoutMetadata.name} to group ${layoutMetadata.group}`);
-    saveLayout(layoutMetadata)
-    setDialogContent(undefined)
+    persistenceManager.saveLayout(layoutMetadata);
+    setDialogContent(undefined);
   }, []);
 
   const [buildMenuOptions, handleMenuAction] = useMemo<

--- a/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
@@ -13,10 +13,7 @@ import {
   LayoutManagementProvider,
   useLayoutManager
 } from "@finos/vuu-shell";
-import {
-  LocalLayoutPersistenceManager,
-  registerComponent
-} from "@finos/vuu-layout";
+import { registerComponent } from "@finos/vuu-layout";
 import { TableSettingsPanel } from "@finos/vuu-table-extras";
 import {
   ContextMenuProvider,

--- a/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
@@ -13,7 +13,10 @@ import {
   LayoutManagementProvider,
   useLayoutManager
 } from "@finos/vuu-shell";
-import { registerComponent } from "@finos/vuu-layout";
+import {
+  LocalLayoutPersistenceManager,
+  registerComponent
+} from "@finos/vuu-layout";
 import { TableSettingsPanel } from "@finos/vuu-table-extras";
 import {
   ContextMenuProvider,
@@ -46,7 +49,6 @@ const ShellWithNewTheme = () => {
   const { saveLayout } = useLayoutManager();
 
   const handleSave = useCallback((layoutMetadata: Omit<LayoutMetadata, "id">) => {
-    console.log(`Save layout as ${layoutMetadata.name} to group ${layoutMetadata.group}`);
     saveLayout(layoutMetadata)
     setDialogContent(undefined)
   }, []);
@@ -185,8 +187,9 @@ const ShellWithNewTheme = () => {
 };
 
 export const ShellWithNewThemeAndLayoutManagement = () => {
+  const pm = new LocalLayoutPersistenceManager();
   return (
-    <LayoutManagementProvider>
+    <LayoutManagementProvider persistenceManager={pm}>
       <ShellWithNewTheme />
     </LayoutManagementProvider>
   )

--- a/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
@@ -48,7 +48,7 @@ const ShellWithNewTheme = () => {
 
   const { saveLayout } = useLayoutManager();
 
-  const handleSave = useCallback((layoutMetadata: LayoutMetadata) => {
+  const handleSave = useCallback((layoutMetadata: Omit<LayoutMetadata, "id">) => {
     saveLayout(layoutMetadata)
     setDialogContent(undefined)
   }, []);

--- a/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
@@ -48,7 +48,7 @@ const ShellWithNewTheme = () => {
 
   const { saveLayout } = useLayoutManager();
 
-  const handleSave = useCallback((layoutMetadata: Omit<LayoutMetadata, "id">) => {
+  const handleSave = useCallback((layoutMetadata: LayoutMetadata) => {
     saveLayout(layoutMetadata)
     setDialogContent(undefined)
   }, []);


### PR DESCRIPTION
### Description
Refactors the layout persistence mechanism to work through an interface. We are currently saving layouts to the browser's local storage, but these changes will allow us to easily introduce other methods of persistence, such as a remote database.

### Change List
- Add `LayoutPersistenceManager` interface
- Implement new interface with `LocalLayoutPersistenceManager`
- Redirect `useLayoutManagement` hook to make use of new interface
- Remove props from `Dialog` (in `NewTheme`) and `LeftNav` (fixes from previous rebase)
- Pass persistence manager in from `NewTheme`

### Notes
- We should only need to load metadata when browsing layouts, but this change will probably make more sense after doing the JSON refactor in #26.
- Target branch is currently set to the one created recently to merge into the Finos fork. We may need to sync the `layout-management-feature` and change the target branch here.

Closes #20