### PR TITLE
 Manage layout persistence via interface

### DIFF
--- a/vuu-ui/package-lock.json
+++ b/vuu-ui/package-lock.json
@@ -11721,6 +11721,7 @@
       }
     },
     "sample-apps/feature-basket-trading": {
+      "name": "feature-vuu-basket-trading",
       "version": "0.0.26",
       "license": "Apache-2.0",
       "dependencies": {
@@ -11782,6 +11783,7 @@
       }
     },
     "sample-apps/feature-instrument-tiles": {
+      "name": "feature-vuu-instrument-tiles",
       "version": "0.0.26",
       "license": "Apache-2.0",
       "dependencies": {
@@ -11812,6 +11814,7 @@
       }
     },
     "sample-apps/feature-template": {
+      "name": "feature-vuu-template",
       "version": "0.0.26",
       "license": "Apache-2.0",
       "dependencies": {

--- a/vuu-ui/packages/vuu-layout/src/index.ts
+++ b/vuu-ui/packages/vuu-layout/src/index.ts
@@ -6,6 +6,7 @@ export * from "./DraggableLayout";
 export * from "./flexbox";
 export { Action } from "./layout-action";
 export * from "./layout-header";
+export * from "./layout-persistence";
 export * from "./layout-provider";
 export * from "./layout-reducer";
 export * from "./layout-view";

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -1,0 +1,46 @@
+import { LayoutJSON } from "@finos/vuu-layout";
+import { LayoutMetadata } from "@finos/vuu-shell";
+
+export interface LayoutPersistenceManager {
+  /**
+   * Saves a new layout
+   *
+   * @param metadata - Metadata about the layout to be saved
+   * @param layout   - Full JSON representation of the layout to be saved
+   *
+   * @returns ID assigned to the saved layout
+   */
+  createLayout: (metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => string;
+
+  /**
+   * Overwrites an existing layout with a new one
+   *
+   * @param id       - Unique identifier of the existing layout to be updated
+   * @param metadata - Metadata describing the new layout to overwrite with
+   * @param layout   - Full JSON representation of the new layout to overwrite with
+   */
+  updateLayout: (id: string, metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => void;
+
+  /**
+   * Deletes an existing layout
+   *
+   * @param id - Unique identifier of the existing layout to be deleted
+   */
+  deleteLayout: (id: string) => void;
+
+  /**
+   * Retrieves an existing layout
+   *
+   * @param id - Unique identifier of the existing layout to be retrieved
+   *
+   * @returns the layout corresponding to provided metadata
+   */
+  loadLayout: (id: string) => LayoutJSON;
+
+  /**
+   * Retrieves metadata for all existing layouts
+   *
+   * @returns an array of all persisted layout metadata
+   */
+  loadMetadata: () => LayoutMetadata[];
+}

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -3,17 +3,17 @@ import { LayoutMetadata } from "@finos/vuu-shell";
 
 export interface LayoutPersistenceManager {
   /**
-   * Saves a new layout
+   * Saves a new layout and its corresponding metadata
    *
    * @param metadata - Metadata about the layout to be saved
    * @param layout   - Full JSON representation of the layout to be saved
    *
-   * @returns ID assigned to the saved layout
+   * @returns Unique identifier assigned to the saved layout
    */
   createLayout: (metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => string;
 
   /**
-   * Overwrites an existing layout with a new one
+   * Overwrites an existing layout and its corresponding metadata with the provided infromation
    *
    * @param id       - Unique identifier of the existing layout to be updated
    * @param metadata - Metadata describing the new layout to overwrite with
@@ -22,7 +22,7 @@ export interface LayoutPersistenceManager {
   updateLayout: (id: string, metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => void;
 
   /**
-   * Deletes an existing layout
+   * Deletes an existing layout and its corresponding metadata
    *
    * @param id - Unique identifier of the existing layout to be deleted
    */
@@ -33,7 +33,7 @@ export interface LayoutPersistenceManager {
    *
    * @param id - Unique identifier of the existing layout to be retrieved
    *
-   * @returns the layout corresponding to provided metadata
+   * @returns Full JSON representation of the layout corresponding to the provided ID
    */
   loadLayout: (id: string) => LayoutJSON;
 

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -1,0 +1,79 @@
+import { Layout, LayoutMetadata } from "@finos/vuu-shell";
+import { LayoutJSON, LayoutPersistenceManager } from "@finos/vuu-layout";
+
+import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
+import { getUniqueId } from "@finos/vuu-utils";
+
+const metadataSaveLocation = "layouts/metadata";
+const layoutsSaveLocation = "layouts/layouts";
+
+export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
+  createLayout(metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON): string {
+    console.log(`Saving layout as ${metadata.name} to group ${metadata.group}...`);
+
+    const existingLayouts = this.loadLayouts();
+    const existingMetadata = this.loadMetadata();
+
+    const id = getUniqueId();
+
+    this.appendAndPersist(id, metadata, layout, existingLayouts, existingMetadata);
+
+    return id;
+  }
+
+  updateLayout(id: string, metadata: Omit<LayoutMetadata, "id">, newLayoutJson: LayoutJSON): void {
+    const existingLayouts = this.loadLayouts().filter(layout => layout.id !== id);
+    const existingMetadata = this.loadMetadata().filter(metadata => metadata.id !== id);
+
+    this.appendAndPersist(id, metadata, newLayoutJson, existingLayouts, existingMetadata);
+  }
+
+  deleteLayout(id: string): void {
+    const layouts = this.loadLayouts().filter(layout => layout.id !== id);
+    const metadata = this.loadMetadata().filter(metadata => metadata.id !== id);
+
+    this.saveLayoutsWithMetadata(layouts, metadata);
+  }
+
+  loadLayout(id: string): LayoutJSON {
+    const layout = this.loadLayouts().filter(layout => layout.id === id);
+
+    switch (layout.length) {
+      case 1: {
+        return layout[0].json;
+      }
+      case 0: {
+        console.log(`WARNING: no layout exists for ID "${id}"; returning empty layout`);
+        return {} as LayoutJSON;
+      }
+      default: {
+        console.log(`WARNING: multiple layouts exist for ID "${id}"; returning first instance`)
+        return layout[0].json;
+      }
+    }
+  }
+
+  loadMetadata(): LayoutMetadata[] {
+    return getLocalEntity<LayoutMetadata[]>(metadataSaveLocation) || [];
+  }
+
+  private loadLayouts(): Layout[] {
+    return getLocalEntity<Layout[]>(layoutsSaveLocation) || [];
+  }
+
+  private appendAndPersist(newId: string,
+                           newMetadata: Omit<LayoutMetadata, "id">,
+                           newLayout: LayoutJSON,
+                           existingLayouts: Layout[],
+                           existingMetadata: LayoutMetadata[]) {
+    existingLayouts.push({id: newId, json: newLayout});
+    existingMetadata.push({id: newId, ...newMetadata});
+
+    this.saveLayoutsWithMetadata(existingLayouts, existingMetadata);
+  }
+
+  private saveLayoutsWithMetadata(layouts: Layout[], metadata: LayoutMetadata[]): void {
+    saveLocalEntity<Layout[]>(layoutsSaveLocation, layouts);
+    saveLocalEntity<LayoutMetadata[]>(metadataSaveLocation, metadata);
+  }
+}

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/index.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/index.ts
@@ -1,0 +1,2 @@
+export * from './LayoutPersistenceManager';
+export * from './LocalLayoutPersistenceManager';

--- a/vuu-ui/packages/vuu-shell/src/layout-management/LayoutList.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/LayoutList.tsx
@@ -12,14 +12,12 @@ type LayoutGroups = {
 const classBase = "vuuLayoutList";
 
 export const LayoutsList = (props: HTMLAttributes<HTMLDivElement>) => {
-    const { layouts } = useLayoutManager();
-
-    const layoutMetadata = layouts.map(layout => layout.metadata)
+    const { layoutMetadata } = useLayoutManager();
 
     const handleLoadLayout = (layoutId?: string) => {
         // TODO load layout
         console.log("loading layout with id", layoutId)
-        console.log("json:", layouts.find(layout => layout.metadata.id === layoutId))
+        console.log("json:", layoutMetadata.find(metadata => metadata.id === layoutId))
     }
 
     const layoutsByGroup = layoutMetadata.reduce((acc: LayoutGroups, cur) => {

--- a/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
@@ -10,6 +10,6 @@ export type LayoutMetadata = {
 };
 
 export type Layout = {
+  id: string,
   json: LayoutJSON;
-  metadata: LayoutMetadata;
 };

--- a/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
@@ -1,12 +1,12 @@
 import { LayoutJSON } from "@finos/vuu-layout";
 
 export type LayoutMetadata = {
+  id: string;
   name: string;
   group: string;
   screenshot: string;
   user: string;
   date: string;
-  id: string;
 };
 
 export type Layout = {

--- a/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
@@ -85,9 +85,6 @@ const ShellWithNewTheme = () => {
 
   const handleSave = useCallback(
     (layoutMetadata: Omit<LayoutMetadata, "id">) => {
-      console.log(
-        `Save layout as ${layoutMetadata.name} to group ${layoutMetadata.group}`
-      );
       saveLayout(layoutMetadata);
       setDialogContent(undefined);
     },
@@ -229,7 +226,6 @@ const ShellWithNewTheme = () => {
           style={{ maxHeight: 500, borderColor: "#6d188b" }}
           title={"Save Layout"}
           hideCloseButton
-          headerProps={{ className: "dialogHeader" }}
         >
           {dialogContent}
         </Dialog>


### PR DESCRIPTION
### Description
Refactors the layout persistence mechanism to work through an interface. We are currently saving layouts to the browser's local storage, but these changes will allow us to easily introduce other methods of persistence, such as a remote database.

### Change List
- Add `LayoutPersistenceManager` interface
- Implement new interface with `LocalLayoutPersistenceManager`
- Redirect `useLayoutManagement` hook to make use of new interface
- Remove metadata and add ID to `Layout` type
- Change `LayoutList` to only store layout metadata

### Notes
- These changes have already been reviewed under #40, with a different target branch.

Closes #20