### PR TITLE
Add validation for layout/metadata IDs #54

### DIFF
--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -10,7 +10,7 @@ export interface LayoutPersistenceManager {
    *
    * @returns Unique identifier assigned to the saved layout
    */
-  createLayout: (metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => string;
+  createLayout: (metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => Promise<string>;
 
   /**
    * Overwrites an existing layout and its corresponding metadata with the provided infromation
@@ -19,14 +19,14 @@ export interface LayoutPersistenceManager {
    * @param metadata - Metadata describing the new layout to overwrite with
    * @param layout   - Full JSON representation of the new layout to overwrite with
    */
-  updateLayout: (id: string, metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => void;
+  updateLayout: (id: string, metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON) => Promise<void>;
 
   /**
    * Deletes an existing layout and its corresponding metadata
    *
    * @param id - Unique identifier of the existing layout to be deleted
    */
-  deleteLayout: (id: string) => void;
+  deleteLayout: (id: string) => Promise<void>;
 
   /**
    * Retrieves an existing layout
@@ -35,12 +35,12 @@ export interface LayoutPersistenceManager {
    *
    * @returns Full JSON representation of the layout corresponding to the provided ID
    */
-  loadLayout: (id: string) => LayoutJSON;
+  loadLayout: (id: string) => Promise<LayoutJSON>;
 
   /**
    * Retrieves metadata for all existing layouts
    *
    * @returns an array of all persisted layout metadata
    */
-  loadMetadata: () => LayoutMetadata[];
+  loadMetadata: () => Promise<LayoutMetadata[]>;
 }

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -1,79 +1,78 @@
 import { Layout, LayoutMetadata } from "@finos/vuu-shell";
 import { LayoutJSON, LayoutPersistenceManager } from "@finos/vuu-layout";
 
-import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
+// import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
+import { getLocalEntity, saveLocalEntity } from "../../../vuu-filters/src/local-config";
 import { getUniqueId } from "@finos/vuu-utils";
-import { warningLayout } from "./data";
 
 const metadataSaveLocation = "layouts/metadata";
 const layoutsSaveLocation = "layouts/layouts";
 
 export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
   createLayout(metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON): Promise<string> {
-    return new Promise(async (resolve) =>{
+    return new Promise(async (resolve) => {
       console.log(`Saving layout as ${metadata.name} to group ${metadata.group}...`);
-      
-      const existingLayouts = this.loadLayouts();
+
+      const existingLayouts = await this.loadLayouts();
       const existingMetadata = await this.loadMetadata();
-      
+
       const id = getUniqueId();
-      
+
       this.appendAndPersist(id, metadata, layout, existingLayouts, existingMetadata);
-      
+
       resolve(id);
     })
   }
 
   updateLayout(id: string, metadata: Omit<LayoutMetadata, "id">, newLayoutJson: LayoutJSON): Promise<void> {
-    return new Promise(async (resolve)=> {
-      const existingLayouts = this.loadLayouts().filter(layout => layout.id !== id);
-      const existingMetadata = (await this.loadMetadata()).filter(metadata => metadata.id !== id);
-        this.appendAndPersist(id, metadata, newLayoutJson, existingLayouts, existingMetadata);
-        resolve()
-    })
+    return new Promise(async (resolve, reject) => {
+      this.validateIds(id)
+        .then(async () => {
+          const existingLayouts = (await this.loadLayouts()).filter(layout => layout.id !== id);
+          const existingMetadata = (await this.loadMetadata()).filter(metadata => metadata.id !== id);
+          this.appendAndPersist(id, metadata, newLayoutJson, existingLayouts, existingMetadata);
+          resolve();
+        })
+        .catch(e => reject(e));
+    });
   }
 
   deleteLayout(id: string): Promise<void> {
-    return new Promise(async (resolve) => {
-      const layouts = this.loadLayouts().filter((layout) => layout.id !== id);
-      const metadata = ( await this.loadMetadata()).filter(metadata => metadata.id !== id);
-        this.saveLayoutsWithMetadata(layouts, metadata);
-        resolve()
+    return new Promise(async (resolve, reject) => {
+      this.validateIds(id)
+        .then(async () => {
+          const layouts = (await this.loadLayouts()).filter((layout) => layout.id !== id);
+          const metadata = (await this.loadMetadata()).filter(metadata => metadata.id !== id);
+          this.saveLayoutsWithMetadata(layouts, metadata);
+          resolve();
+        })
+        .catch(e => reject(e));
     });
   }
 
   loadLayout(id: string): Promise<LayoutJSON> {
-    return new Promise((resolve) => {
-      const layout = this.loadLayouts().filter((layout) => layout.id === id);
-
-      switch (layout.length) {
-        case 1: {
-          resolve(layout[0].json);
-          break;
-        }
-        case 0: {
-          console.log(`WARNING: no layout exists for ID "${id}"; returning empty layout`);
-          resolve(warningLayout);
-          break;
-        }
-        default: {
-          console.log(`WARNING: multiple layouts exist for ID "${id}"; returning first instance`);
-          resolve(layout[0].json);
-          break;
-        }
-      }
+    return new Promise((resolve, reject) => {
+      this.validateId(id, false)
+        .then(async () => {
+          const layouts = (await this.loadLayouts()).filter(layout => layout.id === id);
+          resolve(layouts[0].json);
+        })
+        .catch(e => reject(e));
     });
   }
 
   loadMetadata(): Promise<LayoutMetadata[]> {
     return new Promise((resolve) => {
       const metadata = getLocalEntity<LayoutMetadata[]>(metadataSaveLocation);
-        resolve(metadata || [])
+      resolve(metadata || []);
     })
   }
 
-  private loadLayouts(): Layout[] {
-    return getLocalEntity<Layout[]>(layoutsSaveLocation) || [];
+  private loadLayouts(): Promise<Layout[]> {
+    return new Promise((resolve) => {
+      const layouts = getLocalEntity<Layout[]>(layoutsSaveLocation);
+      resolve(layouts || []);
+    });
   }
 
   private appendAndPersist(
@@ -95,5 +94,39 @@ export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
   ): void {
     saveLocalEntity<Layout[]>(layoutsSaveLocation, layouts);
     saveLocalEntity<LayoutMetadata[]>(metadataSaveLocation, metadata);
+  }
+
+  private async validateIds(id: string): Promise<void> {
+    return Promise
+      .all([
+        this.validateId(id, true).catch(error => error.message),
+        this.validateId(id, false).catch(error => error.message)
+      ])
+      .then((errorMessages: string[]) => {
+        const combinedMessage = errorMessages.filter(Boolean).join("; ");
+        if (combinedMessage) {
+          throw new Error(combinedMessage);
+        }
+      });
+  }
+
+  private validateId(id: string, metadata: boolean): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const loadFunc = metadata ? this.loadMetadata : this.loadLayouts;
+      loadFunc().then(result => {
+        const count = result.filter(x => x.id === id).length;
+        switch (count) {
+          case 1: {
+            resolve();
+            break;
+          };
+          case 0: {
+            reject(new Error(`No ${metadata ? "metadata" : "layout"} with ID ${id}`));
+            break;
+          }
+          default: reject(new Error(`Non-unique ${metadata ? "metadata" : "layout"} with ID ${id}`));
+        }
+      });
+    })
   }
 }

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -1,8 +1,7 @@
 import { Layout, LayoutMetadata } from "@finos/vuu-shell";
 import { LayoutJSON, LayoutPersistenceManager } from "@finos/vuu-layout";
 
-// import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
-import { getLocalEntity, saveLocalEntity } from "../../../vuu-filters/src/local-config";
+import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
 import { getUniqueId } from "@finos/vuu-utils";
 
 const metadataSaveLocation = "layouts/metadata";

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -3,76 +3,96 @@ import { LayoutJSON, LayoutPersistenceManager } from "@finos/vuu-layout";
 
 import { getLocalEntity, saveLocalEntity } from "@finos/vuu-filters";
 import { getUniqueId } from "@finos/vuu-utils";
+import { warningLayout } from "./data";
 
 const metadataSaveLocation = "layouts/metadata";
 const layoutsSaveLocation = "layouts/layouts";
 
 export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
-  createLayout(metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON): string {
-    console.log(`Saving layout as ${metadata.name} to group ${metadata.group}...`);
-
-    const existingLayouts = this.loadLayouts();
-    const existingMetadata = this.loadMetadata();
-
-    const id = getUniqueId();
-
-    this.appendAndPersist(id, metadata, layout, existingLayouts, existingMetadata);
-
-    return id;
+  createLayout(metadata: Omit<LayoutMetadata, "id">, layout: LayoutJSON): Promise<string> {
+    return new Promise(async (resolve) =>{
+      console.log(`Saving layout as ${metadata.name} to group ${metadata.group}...`);
+      
+      const existingLayouts = this.loadLayouts();
+      const existingMetadata = await this.loadMetadata();
+      
+      const id = getUniqueId();
+      
+      this.appendAndPersist(id, metadata, layout, existingLayouts, existingMetadata);
+      
+      resolve(id);
+    })
   }
 
-  updateLayout(id: string, metadata: Omit<LayoutMetadata, "id">, newLayoutJson: LayoutJSON): void {
-    const existingLayouts = this.loadLayouts().filter(layout => layout.id !== id);
-    const existingMetadata = this.loadMetadata().filter(metadata => metadata.id !== id);
-
-    this.appendAndPersist(id, metadata, newLayoutJson, existingLayouts, existingMetadata);
+  updateLayout(id: string, metadata: Omit<LayoutMetadata, "id">, newLayoutJson: LayoutJSON): Promise<void> {
+    return new Promise(async (resolve)=> {
+      const existingLayouts = this.loadLayouts().filter(layout => layout.id !== id);
+      const existingMetadata = (await this.loadMetadata()).filter(metadata => metadata.id !== id);
+        this.appendAndPersist(id, metadata, newLayoutJson, existingLayouts, existingMetadata);
+        resolve()
+    })
   }
 
-  deleteLayout(id: string): void {
-    const layouts = this.loadLayouts().filter(layout => layout.id !== id);
-    const metadata = this.loadMetadata().filter(metadata => metadata.id !== id);
-
-    this.saveLayoutsWithMetadata(layouts, metadata);
+  deleteLayout(id: string): Promise<void> {
+    return new Promise(async (resolve) => {
+      const layouts = this.loadLayouts().filter((layout) => layout.id !== id);
+      const metadata = ( await this.loadMetadata()).filter(metadata => metadata.id !== id);
+        this.saveLayoutsWithMetadata(layouts, metadata);
+        resolve()
+    });
   }
 
-  loadLayout(id: string): LayoutJSON {
-    const layout = this.loadLayouts().filter(layout => layout.id === id);
+  loadLayout(id: string): Promise<LayoutJSON> {
+    return new Promise((resolve) => {
+      const layout = this.loadLayouts().filter((layout) => layout.id === id);
 
-    switch (layout.length) {
-      case 1: {
-        return layout[0].json;
+      switch (layout.length) {
+        case 1: {
+          resolve(layout[0].json);
+          break;
+        }
+        case 0: {
+          console.log(`WARNING: no layout exists for ID "${id}"; returning empty layout`);
+          resolve(warningLayout);
+          break;
+        }
+        default: {
+          console.log(`WARNING: multiple layouts exist for ID "${id}"; returning first instance`);
+          resolve(layout[0].json);
+          break;
+        }
       }
-      case 0: {
-        console.log(`WARNING: no layout exists for ID "${id}"; returning empty layout`);
-        return {} as LayoutJSON;
-      }
-      default: {
-        console.log(`WARNING: multiple layouts exist for ID "${id}"; returning first instance`)
-        return layout[0].json;
-      }
-    }
+    });
   }
 
-  loadMetadata(): LayoutMetadata[] {
-    return getLocalEntity<LayoutMetadata[]>(metadataSaveLocation) || [];
+  loadMetadata(): Promise<LayoutMetadata[]> {
+    return new Promise((resolve) => {
+      const metadata = getLocalEntity<LayoutMetadata[]>(metadataSaveLocation);
+        resolve(metadata || [])
+    })
   }
 
   private loadLayouts(): Layout[] {
     return getLocalEntity<Layout[]>(layoutsSaveLocation) || [];
   }
 
-  private appendAndPersist(newId: string,
-                           newMetadata: Omit<LayoutMetadata, "id">,
-                           newLayout: LayoutJSON,
-                           existingLayouts: Layout[],
-                           existingMetadata: LayoutMetadata[]) {
-    existingLayouts.push({id: newId, json: newLayout});
-    existingMetadata.push({id: newId, ...newMetadata});
+  private appendAndPersist(
+    newId: string,
+    newMetadata: Omit<LayoutMetadata, "id">,
+    newLayout: LayoutJSON,
+    existingLayouts: Layout[],
+    existingMetadata: LayoutMetadata[]
+  ) {
+    existingLayouts.push({ id: newId, json: newLayout });
+    existingMetadata.push({ id: newId, ...newMetadata });
 
     this.saveLayoutsWithMetadata(existingLayouts, existingMetadata);
   }
 
-  private saveLayoutsWithMetadata(layouts: Layout[], metadata: LayoutMetadata[]): void {
+  private saveLayoutsWithMetadata(
+    layouts: Layout[],
+    metadata: LayoutMetadata[]
+  ): void {
     saveLocalEntity<Layout[]>(layoutsSaveLocation, layouts);
     saveLocalEntity<LayoutMetadata[]>(metadataSaveLocation, metadata);
   }

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/data.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/data.ts
@@ -1,0 +1,14 @@
+export const warningLayout = {
+    type: "View",
+    props: {
+      style: { height: "calc(100% - 6px)" },
+    },
+    children: [
+      {
+        props: {
+          className: "vuuShell-warningPlaceholder",
+        },
+        type: "Placeholder",
+      },
+    ],
+  };

--- a/vuu-ui/packages/vuu-layout/test/layout-persistence/LocalLayoutPersistenceManager.test.ts
+++ b/vuu-ui/packages/vuu-layout/test/layout-persistence/LocalLayoutPersistenceManager.test.ts
@@ -4,6 +4,23 @@ import { LocalLayoutPersistenceManager } from "../../src/layout-persistence";
 import { LayoutJSON } from "../../src";
 import { getLocalEntity, saveLocalEntity } from "../../../vuu-filters/src/local-config";
 
+vi.mock("@finos/vuu-filters", async () => {
+  return {
+    getLocalEntity: <T>(url: string): T | undefined => {
+      const data = localStorage.getItem(url);
+      return data ? JSON.parse(data) : undefined;
+    },
+    saveLocalEntity: <T>(url: string, data: T): T | undefined => {
+      try {
+        localStorage.setItem(url, JSON.stringify(data));
+        return data;
+      } catch {
+        return undefined;
+      }
+    },
+  }
+});
+
 const persistenceManager = new LocalLayoutPersistenceManager();
 
 const existingId = "existing_id";

--- a/vuu-ui/packages/vuu-layout/test/layout-persistence/LocalLayoutPersistenceManager.test.ts
+++ b/vuu-ui/packages/vuu-layout/test/layout-persistence/LocalLayoutPersistenceManager.test.ts
@@ -1,0 +1,518 @@
+import { Layout, LayoutMetadata } from "@finos/vuu-shell";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocalLayoutPersistenceManager } from "../../src/layout-persistence";
+import { LayoutJSON } from "../../src";
+import { getLocalEntity, saveLocalEntity } from "../../../vuu-filters/src/local-config";
+
+const persistenceManager = new LocalLayoutPersistenceManager();
+
+const existingId = "existing_id";
+
+const existingMetadata: LayoutMetadata = {
+  id: existingId,
+  name: "Existing Layout",
+  group: "Group 1",
+  screenshot: "screenshot",
+  user: "vuu user",
+  date: "01/01/2023",
+};
+
+const existingLayout: Layout = {
+  id: existingId,
+  json: { type: "t0" }
+};
+
+const metadataToAdd: Omit<LayoutMetadata, "id"> = {
+  name: "New Layout",
+  group: "Group 1",
+  screenshot: "screenshot",
+  user: "vuu user",
+  date: "26/09/2023",
+};
+
+const layoutToAdd: LayoutJSON = {
+  type: "t",
+};
+
+const metadataSaveLocation = "layouts/metadata";
+const layoutsSaveLocation = "layouts/layouts";
+
+afterEach(() => {
+  localStorage.clear();
+})
+
+describe("createLayout", () => {
+
+  it("persists to local storage with a unique ID", async () => {
+    const returnedId = await persistenceManager.createLayout(metadataToAdd, layoutToAdd);
+
+    const persistedMetadata = getLocalEntity<LayoutMetadata[]>(metadataSaveLocation);
+    const persistedLayout = getLocalEntity<Layout[]>(layoutsSaveLocation);
+
+    const expectedMetadata: LayoutMetadata = {
+      ...metadataToAdd,
+      id: returnedId
+    };
+
+    const expectedLayout: Layout = {
+      json: layoutToAdd,
+      id: returnedId
+    };
+
+    expect(persistedMetadata).toEqual([expectedMetadata]);
+    expect(persistedLayout).toEqual([expectedLayout]);
+  });
+
+  it("adds to existing storage", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata]);
+    saveLocalEntity(layoutsSaveLocation, [existingLayout]);
+
+    const returnedId = await persistenceManager.createLayout(metadataToAdd, layoutToAdd);
+    expect(returnedId).not.toEqual(existingId);
+
+    const persistedMetadata = getLocalEntity<LayoutMetadata[]>(metadataSaveLocation);
+    const persistedLayout = getLocalEntity<Layout[]>(layoutsSaveLocation);
+
+    const expectedMetadata: LayoutMetadata = {
+      ...metadataToAdd,
+      id: returnedId,
+    };
+
+    const expectedLayout: Layout = {
+      json: layoutToAdd,
+      id: returnedId,
+    };
+
+    expect(persistedMetadata).toEqual([existingMetadata, expectedMetadata]);
+    expect(persistedLayout).toEqual([existingLayout, expectedLayout]);
+  });
+});
+
+describe("updateLayout", () => {
+
+  it("updates an existing layout", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata]);
+    saveLocalEntity(layoutsSaveLocation, [existingLayout]);
+
+    await persistenceManager.updateLayout(existingId, metadataToAdd, layoutToAdd);
+
+    const persistedMetadata = getLocalEntity<LayoutMetadata[]>(metadataSaveLocation);
+    const persistedLayout = getLocalEntity<Layout[]>(layoutsSaveLocation);
+
+    const expectedMetadata: LayoutMetadata = {
+      ...metadataToAdd,
+      id: existingId,
+    };
+
+    const expectedLayout: Layout = {
+      json: layoutToAdd,
+      id: existingId,
+    };
+
+    expect(persistedMetadata).toEqual([expectedMetadata]);
+    expect(persistedLayout).toEqual([expectedLayout]);
+  });
+
+  it("errors if there is no metadata in local storage with requested ID ", async () => {
+    saveLocalEntity(layoutsSaveLocation, [existingLayout]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.updateLayout(existingId, metadataToAdd, layoutToAdd)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`No metadata with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there is no layout in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata]);
+
+    var exceptionCaught = false;
+
+    await persistenceManager.updateLayout(existingId, metadataToAdd, layoutToAdd)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`No layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there is no metadata or layout in local storage with requested ID ", async () => {
+    const requestedId = "non_existant_id";
+    var exceptionCaught = false;
+
+    persistenceManager.updateLayout(requestedId, metadataToAdd, layoutToAdd)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`No metadata with ID ${requestedId}; No layout with ID ${requestedId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there are multiple metadata entries in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata, existingMetadata]);
+    saveLocalEntity(layoutsSaveLocation, [existingLayout]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.updateLayout(existingId, metadataToAdd, layoutToAdd)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`Non-unique metadata with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there are multiple layouts in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata]);
+    saveLocalEntity(layoutsSaveLocation, [existingLayout, existingLayout]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.updateLayout(existingId, metadataToAdd, layoutToAdd)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`Non-unique layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there are multiple metadata entries and multiple layouts in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata, existingMetadata]);
+    saveLocalEntity(layoutsSaveLocation, [existingLayout, existingLayout]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.updateLayout(existingId, metadataToAdd, layoutToAdd)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`Non-unique metadata with ID ${existingId}; Non-unique layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there are multiple metadata entries and no layouts in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata, existingMetadata]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.updateLayout(existingId, metadataToAdd, layoutToAdd)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`Non-unique metadata with ID ${existingId}; No layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there are no metadata entries and multiple layouts in local storage with requested ID ", async () => {
+    saveLocalEntity(layoutsSaveLocation, [existingLayout, existingLayout]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.updateLayout(existingId, metadataToAdd, layoutToAdd)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`No metadata with ID ${existingId}; Non-unique layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+});
+
+describe("deleteLayout", () => {
+
+  it("removes items from storage", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata]);
+    saveLocalEntity(layoutsSaveLocation, [existingLayout]);
+
+    await persistenceManager.deleteLayout(existingId);
+
+    const persistedMetadata = getLocalEntity<LayoutMetadata[]>(metadataSaveLocation);
+    const persistedLayouts = getLocalEntity<Layout[]>(layoutsSaveLocation);
+
+    expect(persistedMetadata).toEqual([]);
+    expect(persistedLayouts).toEqual([]);
+  })
+
+  it("errors if there is no metadata in local storage with requested ID ", async () => {
+    saveLocalEntity(layoutsSaveLocation, [existingLayout]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.deleteLayout(existingId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`No metadata with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there is no layout in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata]);
+
+    var exceptionCaught = false;
+
+    await persistenceManager.deleteLayout(existingId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`No layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there is no metadata or layout in local storage with requested ID ", async () => {
+    const requestedId = "non_existant_id";
+    var exceptionCaught = false;
+
+    persistenceManager.deleteLayout(requestedId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`No metadata with ID ${requestedId}; No layout with ID ${requestedId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there are multiple metadata entries in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata, existingMetadata]);
+    saveLocalEntity(layoutsSaveLocation, [existingLayout]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.deleteLayout(existingId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`Non-unique metadata with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there are multiple layouts in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata]);
+    saveLocalEntity(layoutsSaveLocation, [existingLayout, existingLayout]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.deleteLayout(existingId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`Non-unique layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there are multiple metadata entries and multiple layouts in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata, existingMetadata]);
+    saveLocalEntity(layoutsSaveLocation, [existingLayout, existingLayout]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.deleteLayout(existingId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`Non-unique metadata with ID ${existingId}; Non-unique layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there are multiple metadata entries and no layouts in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata, existingMetadata]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.deleteLayout(existingId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`Non-unique metadata with ID ${existingId}; No layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there are no metadata entries and multiple layouts in local storage with requested ID ", async () => {
+    saveLocalEntity(layoutsSaveLocation, [existingLayout, existingLayout]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.deleteLayout(existingId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`No metadata with ID ${existingId}; Non-unique layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+});
+
+describe("loadLayout", () => {
+
+  it("retrieves a persisted layout", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata]);
+    saveLocalEntity(layoutsSaveLocation, [existingLayout]);
+
+    const retrievedLayout = await persistenceManager.loadLayout(existingId);
+
+    expect(retrievedLayout).toEqual(existingLayout.json);
+  });
+
+  it("retrieves layout if there is no metadata in local storage with requested ID ", async () => {
+    saveLocalEntity(layoutsSaveLocation, [existingLayout]);
+
+    const retrievedLayout = await persistenceManager.loadLayout(existingId);
+
+    expect(retrievedLayout).toEqual(existingLayout.json);
+  });
+
+  it("errors if there is no layout in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata]);
+
+    var exceptionCaught = false;
+
+    await persistenceManager.loadLayout(existingId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`No layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there is no metadata or layout in local storage with requested ID ", async () => {
+    const requestedId = "non_existant_id";
+    var exceptionCaught = false;
+
+    persistenceManager.loadLayout(requestedId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`No layout with ID ${requestedId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("retrieves layout if there are multiple metadata entries in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata, existingMetadata]);
+    saveLocalEntity(layoutsSaveLocation, [existingLayout]);
+
+    const retrievedLayout = await persistenceManager.loadLayout(existingId);
+
+    expect(retrievedLayout).toEqual(existingLayout.json);
+  });
+
+  it("errors if there are multiple layouts in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata]);
+    saveLocalEntity(layoutsSaveLocation, [existingLayout, existingLayout]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.loadLayout(existingId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`Non-unique layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there are multiple metadata entries and multiple layouts in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata, existingMetadata]);
+    saveLocalEntity(layoutsSaveLocation, [existingLayout, existingLayout]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.loadLayout(existingId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`Non-unique layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there are multiple metadata entries and no layouts in local storage with requested ID ", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata, existingMetadata]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.loadLayout(existingId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`No layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+
+  it("errors if there are no metadata entries and multiple layouts in local storage with requested ID ", async () => {
+    saveLocalEntity(layoutsSaveLocation, [existingLayout, existingLayout]);
+
+    var exceptionCaught = false;
+
+    persistenceManager.loadLayout(existingId)
+      .catch((err: Error) => {
+        exceptionCaught = true;
+        expect(err.message).toEqual(`Non-unique layout with ID ${existingId}`);
+      })
+      .finally(() => {
+        expect(exceptionCaught).toEqual(true);
+      });
+  });
+});
+
+describe("loadMetadata", () => {
+
+  it("retrieves array of persisted layout metadata", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata]);
+
+    const retrievedMetadata = await persistenceManager.loadMetadata();
+
+    expect(retrievedMetadata).toEqual([existingMetadata]);
+  });
+
+  it("retrieves array of all persisted layout metadata", async () => {
+    saveLocalEntity(metadataSaveLocation, [existingMetadata, existingMetadata]);
+
+    const retrievedMetadata = await persistenceManager.loadMetadata();
+
+    expect(retrievedMetadata).toEqual([existingMetadata, existingMetadata]);
+  });
+
+  it("returns empty array if no metadata is persisted", async () => {
+    expect(await persistenceManager.loadMetadata()).toEqual([]);
+  });
+});

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -11,13 +11,14 @@ export const LayoutManagementContext = React.createContext<{
 }>({ layoutMetadata: [], saveLayout: () => { } })
 
 export const LayoutManagementProvider = (props: {
-    children: JSX.Element | JSX.Element[]
-  }) => {
+  children: JSX.Element | JSX.Element[]
+}) => {
   const [layoutMetadata, setLayoutMetadata] = useState<LayoutMetadata[]>([]);
 
   useEffect(() => {
-    const loadedMetadata = persistenceManager.loadMetadata();
-    setLayoutMetadata(loadedMetadata || [])
+    persistenceManager.loadMetadata().then(loadedMetadata => {
+      setLayoutMetadata(loadedMetadata)
+    })
   }, [])
 
   const saveLayout = useCallback((metadata: Omit<LayoutMetadata, "id">) => {
@@ -25,15 +26,16 @@ export const LayoutManagementProvider = (props: {
 
     if (json) {
       // Persist layouts
-      const generatedId = persistenceManager.createLayout(metadata, json);
+      persistenceManager.createLayout(metadata, json).then(generatedId => {
 
-      // Update state
-      const newMetadata: LayoutMetadata = {
-        ...metadata,
-        id: generatedId
-      };
+        // Update state
+        const newMetadata: LayoutMetadata = {
+          ...metadata,
+          id: generatedId
+        };
 
-      setLayoutMetadata(prev => [...prev, newMetadata]);
+        setLayoutMetadata(prev => [...prev, newMetadata]);
+      })
     }
   }, [])
 

--- a/vuu-ui/vitest.config.js
+++ b/vuu-ui/vitest.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["packages/**/test/**.test.(js|ts)"],
+    include: ["packages/**/test/**/**.test.(js|ts)"],
+    environment: 'happy-dom',
   },
 });


### PR DESCRIPTION
### Description
Adds validation to layout management, such that errors are thrown when attempting operations on layouts or metadata that do not have unique entries in local storage.

### Change List
- Adjust `LayoutPersistenceManager` to return promises
- Handle returned promises in `useLayoutManager`
- Add private methods to `LocalLayoutPersistenceManager` to validate IDs:
  - `validateId` ensures there is a unique entry in local storage (metadata or layout, depending on provided flag) corresponding to the provided ID
  - `validateIds` ensures there is a unique metadata entry and a unique layout entry in local storage corresponding to the provided ID
- Add unit tests for all public methods on `LocalLayoutPersistenceManager`
- Add environment to global vitest configuration
- Add data file with warning layout

Closes #54 