### PR TITLE
VUU52: Add E2E tests to CI

### DIFF
--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: cd ./vuu-ui && npm install
       - name: Run end-to-end tests in Chrome
-        uses: cypress-io/github-action@v3
+        uses: cypress-io/github-action@bd9dda317ed2d4fbffc808ba6cdcd27823b2a13b
         with:
           install: false
           working-directory: ./vuu-ui
@@ -50,7 +50,7 @@ jobs:
           start: npm run showcase
           wait-on: "http://localhost:5173"
       - name: Run end-to-end tests in Edge
-        uses: cypress-io/github-action@v3
+        uses: cypress-io/github-action@bd9dda317ed2d4fbffc808ba6cdcd27823b2a13b
         with:
           install: false
           working-directory: ./vuu-ui

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -23,6 +23,42 @@ jobs:
         run: cd ./vuu-ui && npm install
       - run: cd ./vuu-ui && npm run test:vite
 
+  cypress-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+      - name: Install dependencies
+        run: cd ./vuu-ui && npm install
+      - name: Run end-to-end tests in Chrome
+        uses: cypress-io/github-action@v3
+        with:
+          install: false
+          working-directory: ./vuu-ui
+          browser: chrome
+          build: npm run build
+          start: npm run showcase
+          wait-on: "http://localhost:5173"
+      - name: Run end-to-end tests in Edge
+        uses: cypress-io/github-action@v3
+        with:
+          install: false
+          working-directory: ./vuu-ui
+          browser: edge
+          build: npm run build
+          start: npm run showcase
+          wait-on: "http://localhost:5173"
+
   # ensure the vuu example and showcase still build
   vuu-and-showcase-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -24,6 +24,9 @@ jobs:
       - run: cd ./vuu-ui && npm run test:vite
 
   cypress-e2e:
+    # As a third party action, cypress-io is pinned to a full length commit SHA for security purposes.
+    # This is also a requirement for the semgrep (static code analysis) scan to pass.
+    # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/vuu-ui/cypress.config.ts
+++ b/vuu-ui/cypress.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
       viteConfig,
     },
     specPattern: "packages/**/src/**/*.cy.{js,ts,jsx,tsx}",
+    indexHtmlFile: "cypress/support/component/component-index.html",
   },
 
   e2e: {

--- a/vuu-ui/cypress/e2e/layout-management/screenshot.cy.js
+++ b/vuu-ui/cypress/e2e/layout-management/screenshot.cy.js
@@ -17,7 +17,7 @@ context("Screenshot", () => {
     cy.findByRole("menuitem", { name: "Save Layout" }).click();
 
     // TODO (#VUU24): Don't find by classname, use an accessible selector
-    cy.get(".vuuSaveLayoutPanel").then((dialog) => {
+    cy.get(".saveLayoutPanel-panelContainer").then((dialog) => {
       cy.wrap(dialog)
         .find("img")
         .should("be.visible")

--- a/vuu-ui/cypress/support/e2e/constants.ts
+++ b/vuu-ui/cypress/support/e2e/constants.ts
@@ -1,2 +1,2 @@
 export const SHELL_WITH_NEW_THEME_URL =
-  "/Apps/ShellWithNewTheme?standalone&theme=vuu";
+  "/Apps/ShellWithNewThemeAndLayoutManagement?standalone&theme=vuu";


### PR DESCRIPTION
### Description
Adds a job to the Test stage of the CI/CD pipeline to run Cypress end-to-end tests whenever a PR is raised. Tests are set to run in Chrome and Edge until the Firefox bug is fixed (#30).

### Change List
- Add a job to `test-ui.yml` to run Cypress E2E tests
- Fix screenshot test:
  - Change selector for save layout panel
  - Update `SHELL_WITH_NEW_THEME_URL` constant to match changes to the `NewTheme` example
  - Point Cypress config to the correct index HTML file location

Closes #52