### PR TITLE
VUU71: Connect remote implementation of application layouts to server

### DIFF
--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -1,5 +1,9 @@
 import { LayoutJSON } from "@finos/vuu-layout";
-import { LayoutMetadata, LayoutMetadataDto } from "@finos/vuu-shell";
+import {
+  ApplicationLayout,
+  LayoutMetadata,
+  LayoutMetadataDto
+} from "@finos/vuu-shell";
 
 export interface LayoutPersistenceManager {
   /**
@@ -49,7 +53,7 @@ export interface LayoutPersistenceManager {
    *
    * @returns Full JSON representation of the application layout
    */
-  loadApplicationLayout: () => Promise<LayoutJSON>;
+  loadApplicationLayout: () => Promise<ApplicationLayout>;
 
   /**
   * Saves the application layout which includes all layouts on screen

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LayoutPersistenceManager.ts
@@ -1,9 +1,5 @@
 import { LayoutJSON } from "@finos/vuu-layout";
-import {
-  ApplicationLayout,
-  LayoutMetadata,
-  LayoutMetadataDto
-} from "@finos/vuu-shell";
+import { LayoutMetadata, LayoutMetadataDto } from "@finos/vuu-shell";
 
 export interface LayoutPersistenceManager {
   /**
@@ -53,7 +49,7 @@ export interface LayoutPersistenceManager {
    *
    * @returns Full JSON representation of the application layout
    */
-  loadApplicationLayout: () => Promise<ApplicationLayout>;
+  loadApplicationLayout: () => Promise<LayoutJSON>;
 
   /**
   * Saves the application layout which includes all layouts on screen

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -1,5 +1,4 @@
 import {
-  ApplicationLayout,
   Layout,
   LayoutMetadata,
   LayoutMetadataDto,
@@ -112,15 +111,13 @@ export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
     });
   }
 
-  loadApplicationLayout(): Promise<ApplicationLayout> {
-    console.log("LOCAL: LOAD APP LAYOUT");
-    console.log("loadApplicationLAyout");
+  loadApplicationLayout(): Promise<LayoutJSON> {
     return new Promise((resolve) => {
       const applicationLayout = getLocalEntity<LayoutJSON>(this.#urlKey);
       if (applicationLayout) {
-        resolve({username: "vuu-user", definition: applicationLayout});
+        resolve(applicationLayout);
       } else {
-        resolve({username: "vuu-user", definition: defaultLayout});
+        resolve(defaultLayout);
       }
     });
   }

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/LocalLayoutPersistenceManager.ts
@@ -1,4 +1,5 @@
 import {
+  ApplicationLayout,
   Layout,
   LayoutMetadata,
   LayoutMetadataDto,
@@ -111,14 +112,15 @@ export class LocalLayoutPersistenceManager implements LayoutPersistenceManager {
     });
   }
 
-  loadApplicationLayout(): Promise<LayoutJSON> {
+  loadApplicationLayout(): Promise<ApplicationLayout> {
+    console.log("LOCAL: LOAD APP LAYOUT");
     console.log("loadApplicationLAyout");
     return new Promise((resolve) => {
       const applicationLayout = getLocalEntity<LayoutJSON>(this.#urlKey);
       if (applicationLayout) {
-        resolve(applicationLayout);
+        resolve({username: "vuu-user", definition: applicationLayout});
       } else {
-        resolve(defaultLayout);
+        resolve({username: "vuu-user", definition: defaultLayout});
       }
     });
   }

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/RemoteLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/RemoteLayoutPersistenceManager.ts
@@ -1,7 +1,7 @@
 import {
   ApplicationLayout,
   LayoutMetadata,
-  LayoutMetadataDto
+  LayoutMetadataDto,
 } from "@finos/vuu-shell";
 import { LayoutPersistenceManager } from "./LayoutPersistenceManager";
 import { LayoutJSON } from "../layout-reducer";
@@ -143,19 +143,19 @@ export class RemoteLayoutPersistenceManager
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
-          "username": "vuu-user"
+          username: "vuu-user",
         },
         body: JSON.stringify(layout),
       })
-      .then((response) => {
-        if (!response.ok) {
-          reject(new Error(response.statusText));
-        }
-        resolve();
-      })
-      .catch((error: Error) => {
-        reject(error);
-      })
+        .then((response) => {
+          if (!response.ok) {
+            reject(new Error(response.statusText));
+          }
+          resolve();
+        })
+        .catch((error: Error) => {
+          reject(error);
+        })
     );
   }
 
@@ -164,23 +164,27 @@ export class RemoteLayoutPersistenceManager
       fetch(`${baseURL}/${applicationLayoutsSaveLocation}`, {
         method: "GET",
         headers: {
-          "username": "vuu-user",
+          username: "vuu-user",
         },
       })
-      .then((response) => {
-        if (!response.ok) {
-          reject(new Error(response.statusText));
-        }
-        response.json().then((applicationLayout: ApplicationLayout) => {
-          if (!applicationLayout) {
-            reject(new Error("Response did not contain valid application layout information"));
+        .then((response) => {
+          if (!response.ok) {
+            reject(new Error(response.statusText));
           }
-          resolve(applicationLayout.definition);
-        });
-      })
-      .catch((error: Error) => {
-        reject(error);
-      })
+          response.json().then((applicationLayout: ApplicationLayout) => {
+            if (!applicationLayout) {
+              reject(
+                new Error(
+                  "Response did not contain valid application layout information"
+                )
+              );
+            }
+            resolve(applicationLayout.definition);
+          });
+        })
+        .catch((error: Error) => {
+          reject(error);
+        })
     );
   }
 }

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/RemoteLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/RemoteLayoutPersistenceManager.ts
@@ -5,13 +5,13 @@ import {
 } from "@finos/vuu-shell";
 import { LayoutPersistenceManager } from "./LayoutPersistenceManager";
 import { LayoutJSON } from "../layout-reducer";
-import { defaultLayout } from "./data";
 
 const DEFAULT_SERVER_BASE_URL = "http://127.0.0.1:8081/api";
 
 const baseURL = process.env.LAYOUT_BASE_URL ?? DEFAULT_SERVER_BASE_URL;
 const metadataSaveLocation = "layouts/metadata";
 const layoutsSaveLocation = "layouts";
+const applicationLayoutsSaveLocation = "application-layouts";
 
 export type CreateLayoutResponseDto = { metadata: LayoutMetadata };
 export type GetLayoutResponseDto = { definition: LayoutJSON };
@@ -140,14 +140,12 @@ export class RemoteLayoutPersistenceManager
   saveApplicationLayout(layout: LayoutJSON): Promise<void> {
     return new Promise((resolve, reject) =>
       fetch(`${baseURL}/${applicationLayoutsSaveLocation}`, {
-        method: "POST",
+        method: "PUT",
         headers: {
           "Content-Type": "application/json",
-          "user": "vuu-user"
+          "username": "vuu-user"
         },
-        body: JSON.stringify({
-          layoutDefinition: layout,
-        }),
+        body: JSON.stringify(layout),
       })
       .then((response) => {
         if (!response.ok) {
@@ -161,12 +159,12 @@ export class RemoteLayoutPersistenceManager
     );
   }
 
-  loadApplicationLayout(): Promise<ApplicationLayout> {
+  loadApplicationLayout(): Promise<LayoutJSON> {
     return new Promise((resolve, reject) =>
       fetch(`${baseURL}/${applicationLayoutsSaveLocation}`, {
         method: "GET",
         headers: {
-          "user": "vuu-user",
+          "username": "vuu-user",
         },
       })
       .then((response) => {
@@ -175,9 +173,9 @@ export class RemoteLayoutPersistenceManager
         }
         response.json().then((response: ApplicationLayout) => {
           if (!response) {
-            reject(new Error("Response did not contain valid layout information"));
+            reject(new Error("Response did not contain valid application layout information"));
           }
-          resolve(response);
+          resolve(response.definition);
         });
       })
       .catch((error: Error) => {

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/RemoteLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/RemoteLayoutPersistenceManager.ts
@@ -171,11 +171,11 @@ export class RemoteLayoutPersistenceManager
         if (!response.ok) {
           reject(new Error(response.statusText));
         }
-        response.json().then((response: ApplicationLayout) => {
-          if (!response) {
+        response.json().then((applicationLayout: ApplicationLayout) => {
+          if (!applicationLayout) {
             reject(new Error("Response did not contain valid application layout information"));
           }
-          resolve(response.definition);
+          resolve(applicationLayout.definition);
         });
       })
       .catch((error: Error) => {

--- a/vuu-ui/packages/vuu-layout/src/layout-persistence/RemoteLayoutPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-layout/src/layout-persistence/RemoteLayoutPersistenceManager.ts
@@ -1,4 +1,8 @@
-import { LayoutMetadata, LayoutMetadataDto } from "@finos/vuu-shell";
+import {
+  ApplicationLayout,
+  LayoutMetadata,
+  LayoutMetadataDto
+} from "@finos/vuu-shell";
 import { LayoutPersistenceManager } from "./LayoutPersistenceManager";
 import { LayoutJSON } from "../layout-reducer";
 import { defaultLayout } from "./data";
@@ -134,13 +138,51 @@ export class RemoteLayoutPersistenceManager
   }
 
   saveApplicationLayout(layout: LayoutJSON): Promise<void> {
-    // TODO POST api/layouts/application #71
-    console.log(layout);
-    return new Promise((resolve) => resolve());
+    return new Promise((resolve, reject) =>
+      fetch(`${baseURL}/${applicationLayoutsSaveLocation}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "user": "vuu-user"
+        },
+        body: JSON.stringify({
+          layoutDefinition: layout,
+        }),
+      })
+      .then((response) => {
+        if (!response.ok) {
+          reject(new Error(response.statusText));
+        }
+        resolve();
+      })
+      .catch((error: Error) => {
+        reject(error);
+      })
+    );
   }
 
-  loadApplicationLayout(): Promise<LayoutJSON> {
-    // TODO GET api/layouts/application #71
-    return new Promise((resolve) => resolve(defaultLayout));
+  loadApplicationLayout(): Promise<ApplicationLayout> {
+    return new Promise((resolve, reject) =>
+      fetch(`${baseURL}/${applicationLayoutsSaveLocation}`, {
+        method: "GET",
+        headers: {
+          "user": "vuu-user",
+        },
+      })
+      .then((response) => {
+        if (!response.ok) {
+          reject(new Error(response.statusText));
+        }
+        response.json().then((response: ApplicationLayout) => {
+          if (!response) {
+            reject(new Error("Response did not contain valid layout information"));
+          }
+          resolve(response);
+        });
+      })
+      .catch((error: Error) => {
+        reject(error);
+      })
+    );
   }
 }

--- a/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/layoutTypes.ts
@@ -17,3 +17,8 @@ export type LayoutMetadataDto = Omit<LayoutMetadata, "id" | "created">;
 export interface Layout extends WithId {
   json: LayoutJSON;
 }
+
+export type ApplicationLayout = {
+  username: string,
+  definition: LayoutJSON
+};

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -6,13 +6,15 @@ import React, {
   useState,
 } from "react";
 import {
-  ApplicationLayout,
   LayoutJSON,
   LocalLayoutPersistenceManager,
   RemoteLayoutPersistenceManager,
   resolveJSONPath,
 } from "@finos/vuu-layout";
-import { LayoutMetadata, LayoutMetadataDto } from "./layoutTypes";
+import {
+  LayoutMetadata,
+  LayoutMetadataDto
+} from "./layoutTypes";
 import { defaultLayout } from "@finos/vuu-layout/";
 
 const local = process.env.LOCAL ?? true;
@@ -59,20 +61,22 @@ export const LayoutManagementProvider = (
   );
 
   useEffect(() => {
-    persistenceManager.loadMetadata().then((metadata) => {
-      setLayoutMetadata(metadata);
-    });
-    persistenceManager
-      .loadApplicationLayout()
-      .then((layoutDto: ApplicationLayout) => {
-        if (layoutDto.username === null) {
-          persistenceManager.saveApplicationLayout(layoutDto.definition);
-        }
-        setApplicationLayout(layoutDto.definition);
+    persistenceManager.loadMetadata()
+      .then((metadata) => {
+        setLayoutMetadata(metadata);
       })
       .catch((error: Error) => {
         //TODO: Show error toaster
         console.error("Error occurred while retrieving metadata", error);
+      });
+
+      persistenceManager.loadApplicationLayout()
+      .then((layout: LayoutJSON) => {
+        setApplicationLayout(layout);
+      })
+      .catch((error: Error) => {
+        //TODO: Show error toaster
+        console.error("Error occurred while retrieving application layout", error);
       });
   }, [setApplicationLayout]);
 

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from "react";
 import {
+  ApplicationLayout,
   LayoutJSON,
   LocalLayoutPersistenceManager,
   RemoteLayoutPersistenceManager,
@@ -63,8 +64,11 @@ export const LayoutManagementProvider = (
     });
     persistenceManager
       .loadApplicationLayout()
-      .then((layout) => {
-        setApplicationLayout(layout);
+      .then((layoutDto: ApplicationLayout) => {
+        if (layoutDto.username === null) {
+          persistenceManager.saveApplicationLayout(layoutDto.definition);
+        }
+        setApplicationLayout(layoutDto.definition);
       })
       .catch((error: Error) => {
         //TODO: Show error toaster


### PR DESCRIPTION
### Description
When the app is configured to use remote layout persistence, saving and loading application layouts currently has no effect. The changes here allow it to communicate with the layout server, so the application layouts are saved to and retrieved from the database.

### Change List
- Implement fetches from server for saving and loading application layouts in `RemoteLayoutPersistenceManager`
- Add `ApplicationLayout` type to model the server's response body
- Implement separate catches for metadata and application layout retrieval in `useLayoutManager` (plus refactor)
- Remove logging from local layout manager