### PR TITLE
SLVUU-27: Add allowed origins to CORS config

### DIFF
--- a/layout-server/src/main/java/org/finos/vuu/layoutserver/CorsConfig.java
+++ b/layout-server/src/main/java/org/finos/vuu/layoutserver/CorsConfig.java
@@ -9,7 +9,12 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://127.0.0.1:5173")
+                .allowedOrigins(
+                        "http://127.0.0.1:5173",
+                        "https://127.0.0.1:5173",
+                        "http://127.0.0.1:8443/",
+                        "https://127.0.0.1:8443/"
+                )
                 .allowedMethods("GET", "POST", "PUT", "DELETE");
     }
 }


### PR DESCRIPTION
Adds allowed CORS origins for port 8443 (HTTP & HTTPS), as well as HTTPS for port 5173.

[Following feedback from here](https://github.com/finos/vuu/pull/970#discussion_r1395427980)
![image](https://github.com/ScottLogic/finos-vuu/assets/79100986/68249c40-face-4144-8bc0-bb7d232d83c2)
