### PR TITLE
SLVUU-69: Display toast on layout load/save

### DIFF
--- a/vuu-ui/packages/vuu-popups/src/notifications/notifications.css
+++ b/vuu-ui/packages/vuu-popups/src/notifications/notifications.css
@@ -1,7 +1,6 @@
 .vuuToastNotifications-toastContainer {
     --top: 60px;
     position: absolute;
-    z-index: 100000;
     right: 0;
     top: var(--top);
     overflow: hidden;
@@ -18,6 +17,7 @@
     gap: 8px;
     border-radius: 6px;
     box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.40);
+    z-index: 100000;
 }
 
 .vuuToastNotifications-toastContent{

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -93,8 +93,8 @@ export const LayoutManagementProvider = (
       .catch((error: Error) => {
         notify({
           type: NotificationLevel.Error,
-          header: "This Didn't Work",
-          body: "Failed to load metadata from server",
+          header: "Failed to Load Layouts",
+          body: "Could not load list of available layouts",
         });
         console.error("Error occurred while retrieving metadata", error);
       });
@@ -107,8 +107,8 @@ export const LayoutManagementProvider = (
       .catch((error: Error) => {
         notify({
           type: NotificationLevel.Error,
-          header: "This Didn't Work",
-          body: "Failed to load application layout from server",
+          header: "Failed to Load Layout",
+          body: "Could not load your latest view",
         });
         console.error(
           "Error occurred while retrieving application layout",
@@ -146,15 +146,15 @@ export const LayoutManagementProvider = (
           .catch((error: Error) => {
             notify({
               type: NotificationLevel.Error,
-              header: "This Didn't Work",
-              body: "Failed to save layout to server",
+              header: "Failed to Save Layout",
+              body: `Failed to save layout ${metadata.name} to server`,
             });
             console.error("Error occurred while saving layout", error);
           });
       } else {
         notify({
           type: NotificationLevel.Error,
-          header: "This Didn't Work",
+          header: "Failed to Save Layout",
           body: "Cannot save undefined layout",
         });
       }

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -147,7 +147,7 @@ export const LayoutManagementProvider = (
             notify({
               type: NotificationLevel.Error,
               header: "Failed to Save Layout",
-              body: `Failed to save layout ${metadata.name} to server`,
+              body: `Failed to save layout ${metadata.name}`,
             });
             console.error("Error occurred while saving layout", error);
           });
@@ -173,9 +173,17 @@ export const LayoutManagementProvider = (
             active: prev.children?.length ?? 0,
             children: [...(prev.children || []), layoutJson],
           });
+        })
+        .catch((error: Error) => {
+          notify({
+            type: NotificationLevel.Error,
+            header: "Failed to Load Layout",
+            body: "Failed to load the requested layout",
+          });
+          console.error("Error occurred while loading layout", error);
         });
     },
-    [setApplicationLayout]
+    [notify, setApplicationLayout]
   );
 
   return (

--- a/vuu-ui/sample-apps/app-vuu-example/index.tsx
+++ b/vuu-ui/sample-apps/app-vuu-example/index.tsx
@@ -1,3 +1,4 @@
+import { NotificationsProvider } from "@finos/vuu-popups";
 import {
   getAuthDetailsFromCookies,
   LayoutManagementProvider,
@@ -16,9 +17,11 @@ if (!username || !token) {
   redirectToLogin();
 } else {
   ReactDOM.render(
-    <LayoutManagementProvider>
-      <App user={{ username, token }} />
-    </LayoutManagementProvider>,
+    <NotificationsProvider>
+      <LayoutManagementProvider>
+        <App user={{ username, token }} />
+      </LayoutManagementProvider>
+    </NotificationsProvider>,
     document.getElementById("root")
   );
 }

--- a/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
@@ -3,7 +3,11 @@ import {
   registerComponent,
   useLayoutContextMenuItems,
 } from "@finos/vuu-layout";
-import { ContextMenuProvider, useDialog } from "@finos/vuu-popups";
+import {
+  ContextMenuProvider,
+  NotificationsProvider,
+  useDialog,
+} from "@finos/vuu-popups";
 import {
   FeatureConfig,
   FeatureProps,
@@ -141,9 +145,11 @@ const ShellWithNewTheme = () => {
 
 export const ShellWithNewThemeAndLayoutManagement = () => {
   return (
-    <LayoutManagementProvider>
-      <ShellWithNewTheme />
-    </LayoutManagementProvider>
+    <NotificationsProvider>
+      <LayoutManagementProvider>
+        <ShellWithNewTheme />
+      </LayoutManagementProvider>
+    </NotificationsProvider>
   );
 };
 


### PR DESCRIPTION
### Description
Display toast notifications for all relevant scenarios pertaining to layout management.

### Change List
- Wrap the `ShellWithNewThemeAndLayoutManagement` Showcase example with `NotificationsProvider`
- Call `notify` from `useNotifications` in the following instances:
  - Loading metadata returns an error
  - Loading the application layout returns an error
  - A layout is saved successfully
  - Saving a layout returns an error
  - An attempt is made to save an undefined layout

### Testing
Manually tested on the `ShellWithNewThemeAndLayoutManagement` Showcase example by configuring the app to use remote layout management:
- Loading the example without first running the layout server results in an error toast being displayed
- Saving a layout (with the layout server running) results in a success toast being displayed

### Evidence
Success toast displayed after saving a layout:

![SLVUU69-toast-success](https://github.com/ScottLogic/finos-vuu/assets/79100986/df478092-b533-47d5-869c-552daf38064e)

Error toast displayed after shutting down the layout server and refreshing the app:

![SLVUU69-toast-error](https://github.com/ScottLogic/finos-vuu/assets/79100986/0068da67-0e2d-4de8-bb67-1d4b1c71d983)
