### PR TITLE
SLVUU-123: Fix Toast Animation

### DIFF
--- a/vuu-ui/packages/vuu-popups/src/notifications/NotificationsProvider.tsx
+++ b/vuu-ui/packages/vuu-popups/src/notifications/NotificationsProvider.tsx
@@ -94,7 +94,10 @@ export const ToastNotification = (props: ToastNotificationProps) => {
   const [right, setRight] = useState(-toastWidth - toastContainerRightPadding);
 
   useEffect(() => {
-    setRight(toastContainerRightPadding);
+    setTimeout(
+      () => setRight(toastContainerRightPadding)
+    );
+
     if (animated) {
       setTimeout(
         () => setRight(-toastWidth - toastContainerRightPadding),

--- a/vuu-ui/packages/vuu-popups/src/notifications/NotificationsProvider.tsx
+++ b/vuu-ui/packages/vuu-popups/src/notifications/NotificationsProvider.tsx
@@ -60,7 +60,6 @@ export const NotificationsProvider = (props: {
   return (
     <NotificationsContext.Provider value={{ notify }}>
       <div
-        className={`${classBase}-toastContainer`}
         style={{
           width:
             toastWidth + toastContainerRightPadding + toastContainerLeftPadding,

--- a/vuu-ui/packages/vuu-popups/src/notifications/notifications.css
+++ b/vuu-ui/packages/vuu-popups/src/notifications/notifications.css
@@ -1,13 +1,3 @@
-.vuuToastNotifications-toastContainer {
-    --top: 60px;
-    position: absolute;
-    right: 0;
-    top: var(--top);
-    overflow: hidden;
-    height:calc(100% - var(--top));
-    font-size: 12px;
-}
-
 .vuuToastNotifications-toast {
     --vuu-icon-size: 24px;
     position: absolute;


### PR DESCRIPTION
### Description
Fixes the entry animation for toast notifications.

### Change List
- Add nominal timeout around the function that puts the notification on screen
- Refactor: remove unnecessary CSS class

### Testing
- Tested manually on both showcase and sample app
- Manual testing performed in Firefox, Edge and Chrome

### Test Evidence
#### Before
![Image](https://github.com/ScottLogic/finos-vuu/assets/79100986/82de67c6-662f-4312-a0ae-5cff6276044c)

#### After
![SLVUU123-toast-animation-fixed](https://github.com/ScottLogic/finos-vuu/assets/79100986/d9b1025a-bbbf-41da-886b-d962e53f6000)

### Implementation Notes
The `setRight` function changes a CSS property, resulting in the notification moving into the screen from the right. Despite being defined with zero time, the timeout pushes the `setRight` call from the stack to the task queue. This is enough to create a distinction between the offscreen and onscreen positions, so that the transition effect can be seen.